### PR TITLE
Fix charm-ceph config re: osd-reformat

### DIFF
--- a/helper/bundles/ceph-charm-migration.yaml
+++ b/helper/bundles/ceph-charm-migration.yaml
@@ -15,7 +15,7 @@ base:
       options:
         ephemeral-unmount: /mnt
         osd-devices: /dev/vdb /dev/sdb /dev/xvdb
-        osd-reformat: False
+        # osd-reformat: False # charm-ceph doesn't support the more strongly typed configuration
         fsid: 5a791d94-980b-11e4-b6f6-3c970e8b1cf7
         monitor-secret: AQAi5a9UeJXUExAA+By9u+GPhl8/XiUQ4nwI3A==
     ceph-mon:

--- a/helper/bundles/charm-ceph.yaml
+++ b/helper/bundles/charm-ceph.yaml
@@ -15,7 +15,7 @@ base:
       options:
         ephemeral-unmount: /mnt
         osd-devices: /dev/vdb /dev/sdb /dev/xvdb
-        osd-reformat: True
+        osd-reformat: 'truthy string' # charm-ceph doesn't support the more strongly typed configuration
         fsid: 5a791d94-980b-11e4-b6f6-3c970e8b1cf7
         monitor-secret: AQAi5a9UeJXUExAA+By9u+GPhl8/XiUQ4nwI3A==
     ceph-osd:


### PR DESCRIPTION
charm-ceph-osd has been updated to have a more
strictly typed configuration for osd-reformat;
however, charm-ceph has not been updated with
that so we need to continue passing valid types
for charm-ceph

Closes: #1771361