### PR TITLE
Fix ambigious openstack-dashboard keystone relation

### DIFF
--- a/helper/bundles/baremetal7-next.yaml
+++ b/helper/bundles/baremetal7-next.yaml
@@ -159,7 +159,7 @@ openstack-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/baremetal7.yaml
+++ b/helper/bundles/baremetal7.yaml
@@ -159,7 +159,7 @@ openstack-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -144,7 +144,7 @@ base-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/dynamic-routing-next.yaml
+++ b/helper/bundles/dynamic-routing-next.yaml
@@ -136,7 +136,7 @@ base-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/full-dvr-next.yaml
+++ b/helper/bundles/full-dvr-next.yaml
@@ -101,7 +101,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, ceph-mon ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/full-next.yaml
+++ b/helper/bundles/full-next.yaml
@@ -110,7 +110,7 @@ openstack-services:
     - [ cinder, keystone ]
     - [ cinder, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/full-ssl-next.yaml
+++ b/helper/bundles/full-ssl-next.yaml
@@ -114,7 +114,7 @@ openstack-services:
     - [ cinder, keystone ]
     - [ cinder, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/full-ssl.yaml
+++ b/helper/bundles/full-ssl.yaml
@@ -114,7 +114,7 @@ openstack-services:
     - [ cinder, keystone ]
     - [ cinder, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/full-vrrpha-next.yaml
+++ b/helper/bundles/full-vrrpha-next.yaml
@@ -66,7 +66,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
 openstack-singlerabbit:
   inherits: openstack-services
   relations:

--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -116,7 +116,7 @@ openstack-services:
     - [ cinder, keystone ]
     - [ cinder, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/ha-next.yaml
+++ b/helper/bundles/ha-next.yaml
@@ -184,7 +184,7 @@ openstack-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/ha.yaml
+++ b/helper/bundles/ha.yaml
@@ -187,7 +187,7 @@ openstack-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/haphase2-next.yaml
+++ b/helper/bundles/haphase2-next.yaml
@@ -137,7 +137,7 @@ openstack-services:
     - [ cinder-ceph, ceph ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "neutron-gateway:amqp", rabbitmq-server ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ openstack-dashboard, dashboard-hacluster ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-proxy-hacluster ]

--- a/helper/bundles/haphase2.yaml
+++ b/helper/bundles/haphase2.yaml
@@ -141,7 +141,7 @@ openstack-services:
     - [ neutron-gateway, nova-cloud-controller ]
     - [ neutron-gateway, neutron-api ]
     - [ "neutron-gateway:amqp", rabbitmq-server ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ openstack-dashboard, dashboard-hacluster ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-proxy-hacluster ]

--- a/helper/bundles/ksv3-full-next.yaml
+++ b/helper/bundles/ksv3-full-next.yaml
@@ -119,7 +119,7 @@ openstack-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]

--- a/helper/bundles/ksv3-full.yaml
+++ b/helper/bundles/ksv3-full.yaml
@@ -119,7 +119,7 @@ openstack-services:
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
-    - [ openstack-dashboard, keystone ]
+    - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]


### PR DESCRIPTION
The upcoming WebSSO support in Keystone makes the current
openstack-dashboard keystone relation in bundles ambigious.

Change bundles to specifically refer to
openstack-dashboard:identity-service

Fixes #15