### PR TITLE
Add boot from volume test

### DIFF
--- a/helper/bundles/baremetal7-next.yaml
+++ b/helper/bundles/baremetal7-next.yaml
@@ -364,6 +364,8 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-ocata-proposed:
   inherits: xenial-ocata
   overrides:
@@ -374,9 +376,13 @@ xenial-ocata-staging:
   overrides:
     openstack-origin: ppa:ubuntu-cloud-archive/ocata-staging
     source: ppa:ubuntu-cloud-archive/ocata-staging
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata:
   inherits: openstack-icehouse
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-proposed:
   inherits: zesty-ocata
   overrides:
@@ -389,6 +395,8 @@ xenial-pike:
   overrides:
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-pike-proposed:
   inherits: xenial-pike
   overrides:
@@ -402,6 +410,8 @@ xenial-pike-staging:
 artful-pike:
   inherits: openstack-icehouse
   series: artful
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-queens:
   inherits: xenial-pike
   overrides:

--- a/helper/bundles/baremetal7.yaml
+++ b/helper/bundles/baremetal7.yaml
@@ -361,6 +361,8 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-ocata-proposed:
   inherits: xenial-ocata
   overrides:
@@ -374,6 +376,8 @@ xenial-ocata-staging:
 zesty-ocata:
   inherits: openstack-icehouse
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-proposed:
   inherits: zesty-ocata
   overrides:

--- a/helper/bundles/full-dvr-next.yaml
+++ b/helper/bundles/full-dvr-next.yaml
@@ -47,6 +47,8 @@ openstack-services:
         block-device: "None"
         glance-api-version: 2
       constraints": mem=1G
+    cinder-ceph:
+      charm: cinder-ceph
     glance:
       charm: glance
       constraints: mem=1G
@@ -102,7 +104,8 @@ openstack-services:
     - [ cinder, rabbitmq-server ]
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
-    - [ cinder, ceph-mon ]
+    - [ cinder, cinder-ceph ]
+    - [ cinder-ceph, ceph-mon ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]
@@ -267,9 +270,13 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata:
   inherits: openstack-icehouse
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 
 # pike
 xenial-pike:
@@ -278,12 +285,16 @@ xenial-pike:
   overrides:
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-pike:
   inherits: openstack-icehouse
   series: zesty
   overrides:
     openstack-origin: cloud:zesty-pike
     source: cloud:zesty-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # queens
 xenial-queens:
   inherits: xenial-pike

--- a/helper/bundles/full-next.yaml
+++ b/helper/bundles/full-next.yaml
@@ -54,6 +54,8 @@ openstack-services:
         block-device: "None"
         glance-api-version: 2
       constraints": mem=1G
+    cinder-ceph:
+      charm: cinder-ceph
     glance:
       charm: glance
       constraints: mem=1G
@@ -109,7 +111,8 @@ openstack-services:
     - [ cinder, rabbitmq-server ]
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
-    - [ cinder, ceph-mon ]
+    - [ cinder, cinder-ceph ]
+    - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
@@ -338,6 +341,8 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-ocata-proposed:
   inherits: xenial-ocata
   overrides:
@@ -351,6 +356,8 @@ xenial-ocata-staging:
 zesty-ocata:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # pike
 xenial-pike:
   inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
@@ -358,6 +365,8 @@ xenial-pike:
   overrides:
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-pike-proposed:
   inherits: xenial-pike
   overrides:
@@ -371,12 +380,16 @@ xenial-pike-staging:
 artful-pike:
   inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
   series: artful
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-queens:
   inherits: [ openstack-icehouse, ceilometer-gnocchi ]
   series: xenial
   overrides:
     openstack-origin: cloud:xenial-queens/proposed
     source: cloud:xenial-queens/proposed
+  relations:
+    - [ cinder-ceph, nova-compute ]
 bionic-queens:
   inherits: xenial-queens
   series: bionic

--- a/helper/bundles/full-ssl-next.yaml
+++ b/helper/bundles/full-ssl-next.yaml
@@ -58,6 +58,8 @@ openstack-services:
         block-device: "None"
         glance-api-version: 2
       constraints": mem=1G
+    cinder-ceph:
+      charm: cinder-ceph
     glance:
       charm: glance
       constraints: mem=1G
@@ -113,7 +115,8 @@ openstack-services:
     - [ cinder, rabbitmq-server ]
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
-    - [ cinder, ceph-mon ]
+    - [ cinder, cinder-ceph ]
+    - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
@@ -342,6 +345,8 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-ocata-proposed:
   inherits: xenial-ocata
   overrides:
@@ -355,6 +360,8 @@ xenial-ocata-staging:
 zesty-ocata:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-proposed:
   inherits: zesty-ocata
   overrides:
@@ -367,6 +374,8 @@ xenial-pike:
   overrides:
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-pike-proposed:
   inherits: xenial-pike
   overrides:
@@ -380,17 +389,23 @@ xenial-pike-staging:
 artful-pike:
   inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
   series: artful
+  relations:
+    - [ cinder-ceph, nova-compute ]
 artful-pike-proposed:
   inherits: artful-pike
   overrides:
     source: proposed
     openstack-origin: distro-proposed
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-queens:
   inherits: [ openstack-icehouse, ceilometer-gnocchi ]
   series: xenial
   overrides:
     openstack-origin: cloud:xenial-queens/proposed
     source: cloud:xenial-queens/proposed
+  relations:
+    - [ cinder-ceph, nova-compute ]
 bionic-queens:
   inherits: xenial-queens
   series: bionic

--- a/helper/bundles/full-ssl.yaml
+++ b/helper/bundles/full-ssl.yaml
@@ -58,6 +58,8 @@ openstack-services:
         block-device: "None"
         glance-api-version: 2
       constraints": mem=1G
+    cinder-ceph:
+      charm: cinder-ceph
     glance:
       charm: glance
       constraints: mem=1G
@@ -110,7 +112,8 @@ openstack-services:
     - [ cinder, rabbitmq-server ]
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
-    - [ cinder, ceph-mon ]
+    - [ cinder, cinder-ceph ]
+    - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
@@ -339,6 +342,8 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-ocata-proposed:
   inherits: xenial-ocata
   overrides:
@@ -352,6 +357,8 @@ xenial-ocata-staging:
 zesty-ocata:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-proposed:
   inherits: zesty-ocata
   overrides:

--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -57,6 +57,8 @@ openstack-services:
         block-device: "None"
         glance-api-version: 2
       constraints": mem=1G
+    cinder-ceph:
+      charm: cinder-ceph
     glance:
       charm: glance
       constraints: mem=1G
@@ -109,7 +111,8 @@ openstack-services:
     - [ cinder, rabbitmq-server ]
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
-    - [ cinder, ceph-mon ]
+    - [ cinder, cinder-ceph ]
+    - [ cinder-ceph, ceph-mon ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
@@ -344,9 +347,13 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # pike
 xenial-pike:
   inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
@@ -354,6 +361,10 @@ xenial-pike:
   overrides:
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 artful-pike:
   inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
   series: artful
+  relations:
+    - [ cinder-ceph, nova-compute ]

--- a/helper/bundles/ha-next.yaml
+++ b/helper/bundles/ha-next.yaml
@@ -335,11 +335,15 @@ xenial-ocata-ha:
     ha-bindiface: ens2
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: zesty
   overrides:
     ha-bindiface: ens2
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # pike
 xenial-pike-ha:
   inherits: [ openstack-services, ceilometer-mongodb, charm-ceilometer-gnocchi ]
@@ -348,11 +352,15 @@ xenial-pike-ha:
     ha-bindiface: ens2
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 artful-pike-ha:
   inherits: [ openstack-services, ceilometer-mongodb, charm-ceilometer-gnocchi ]
   series: artful
   overrides:
     ha-bindiface: ens2
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # queens
 xenial-queens-ha:
   inherits: [ openstack-services, ceilometer-gnocchi ]
@@ -360,6 +368,8 @@ xenial-queens-ha:
   overrides:
     openstack-origin: cloud:xenial-queens/proposed
     source: cloud:xenial-queens/proposed
+  relations:
+    - [ cinder-ceph, nova-compute ]
 bionic-queens-ha:
   inherits: xenial-queens-ha
   series: bionic

--- a/helper/bundles/ha.yaml
+++ b/helper/bundles/ha.yaml
@@ -331,9 +331,13 @@ xenial-ocata-ha:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # pike
 xenial-pike-ha:
   inherits: [ openstack-services, ceilometer-mongodb, charm-ceilometer-gnocchi ]
@@ -341,6 +345,10 @@ xenial-pike-ha:
   overrides:
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 artful-pike-ha:
   inherits: [ openstack-services, ceilometer-mongodb, charm-ceilometer-gnocchi ]
   series: artful
+  relations:
+    - [ cinder-ceph, nova-compute ]

--- a/helper/bundles/ksv3-full-next.yaml
+++ b/helper/bundles/ksv3-full-next.yaml
@@ -353,6 +353,8 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-ocata-proposed:
   inherits: xenial-ocata
   overrides:
@@ -366,6 +368,8 @@ xenial-ocata-staging:
 zesty-ocata:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-proposed:
   inherits: zesty-ocata
   overrides:
@@ -378,6 +382,8 @@ xenial-pike:
   overrides:
     openstack-origin: cloud:xenial-pike
     source: cloud:xenial-pike
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-pike-proposed:
   inherits: xenial-pike
   overrides:
@@ -391,6 +397,8 @@ xenial-pike-staging:
 artful-pike:
   inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
   series: artful
+  relations:
+    - [ cinder-ceph, nova-compute ]
 artful-pike-proposed:
   inherits: artful-pike
   overrides:
@@ -403,6 +411,8 @@ xenial-queens:
   overrides:
     openstack-origin: cloud:xenial-queens/proposed
     source: cloud:xenial-queens/proposed
+  relations:
+    - [ cinder-ceph, nova-compute ]
 bionic-queens:
   inherits: xenial-queens
   series: bionic

--- a/helper/bundles/ksv3-full.yaml
+++ b/helper/bundles/ksv3-full.yaml
@@ -350,6 +350,8 @@ xenial-ocata:
   overrides:
     openstack-origin: cloud:xenial-ocata
     source: cloud:xenial-ocata
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-ocata-proposed:
   inherits: xenial-ocata
   overrides:
@@ -363,6 +365,8 @@ xenial-ocata-staging:
 zesty-ocata:
   inherits: [ openstack-icehouse-msg-split, ceilometer-mongodb ]
   series: zesty
+  relations:
+    - [ cinder-ceph, nova-compute ]
 zesty-ocata-proposed:
   inherits: zesty-ocata
   overrides:

--- a/helper/tests/simple_os_checks.py
+++ b/helper/tests/simple_os_checks.py
@@ -85,14 +85,31 @@ def main(argv):
         novac.servers.delete(server.id)
     for instanceset in machines:
         image_name, flavor_name, count = instanceset.split(":")
+        # when instance count allows boot instances off both regular instance
+        # storage and volume storage
+        #
+        # account for count=1 and odd numbers
+        regular_boot_count = (int(count) / 2) + (int(count) % 2)
+        volume_boot_count = int(count) / 2
         mojo_os_utils.boot_and_test(novac, neutronc,
                                     image_name=image_name,
                                     flavor_name=flavor_name,
-                                    number=int(count),
+                                    number=regular_boot_count,
                                     privkey=priv_key,
                                     active_wait=active_wait,
                                     cloudinit_wait=cloudinit_wait,
-                                    ping_wait=ping_wait)
+                                    ping_wait=ping_wait,
+                                    )
+        mojo_os_utils.boot_and_test(novac, neutronc,
+                                    image_name=image_name,
+                                    flavor_name=flavor_name,
+                                    number=volume_boot_count,
+                                    privkey=priv_key,
+                                    active_wait=active_wait,
+                                    cloudinit_wait=cloudinit_wait,
+                                    ping_wait=ping_wait,
+                                    boot_from_volume=True,
+                                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Starting OpenStack Ocata, the default mode of operation of OpenStack Dashboard when launching an instance is to launch it from a bootable volume. At the same version a new ceph-access relation between cinder-ceph and nova-compute is required for this to actually work.

Exercise this in the Mojo Specs to catch any regressions.

Fixes https://bugs.launchpad.net/openstack-mojo-specs/+bug/1752584