### PR TITLE
Use old style string based osd-reformat option

### DIFF
--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -24,7 +24,7 @@ openstack-services:
       options:
         ephemeral-unmount: /mnt
         osd-devices: /dev/vdb /dev/sdb /dev/xvdb
-        osd-reformat: True
+        osd-reformat: "yes"
     keystone:
       charm: keystone
       constraints: mem=1G


### PR DESCRIPTION
This can be switched after the release to use the newer
boolean type, but until then the pre-upgrade cloud must
be deployed with the old style string based option