### PR TITLE
Fix 400 error on nova client and various spec tweaks

### DIFF
--- a/helper/bundles/full-osd-reformat-is-text.yaml
+++ b/helper/bundles/full-osd-reformat-is-text.yaml
@@ -1,0 +1,359 @@
+# vim: set ts=2 et:
+#
+# Config and topology for STABLE charms
+#
+openstack-services:
+  services:
+    mysql:
+      charm: mysql
+      constraints: mem=1G
+      options:
+        dataset-size: 50%
+    rabbitmq-server:
+      charm: rabbitmq-server
+      constraints: mem=1G
+    ceph-mon:
+      charm: ceph-mon
+      num_units: 3
+      options:
+        expected-osd-count: 3
+    ceph-osd:
+      charm: ceph-osd
+      constraints: mem=1G
+      num_units: 3
+      options:
+        ephemeral-unmount: /mnt
+        osd-devices: /dev/vdb /dev/sdb /dev/xvdb
+        osd-reformat: 'true'
+    keystone:
+      charm: keystone
+      constraints: mem=1G
+      options:
+        admin-password: openstack
+        admin-token: ubuntutesting
+    openstack-dashboard:
+      charm: openstack-dashboard
+      constraints: mem=1G
+    nova-compute:
+      charm: nova-compute
+      num_units: 3
+      constraints: mem=4G
+      options:
+        enable-live-migration: True
+        enable-resize: True
+        migration-auth-type: ssh
+    nova-cloud-controller:
+      charm: nova-cloud-controller
+      constraints: mem=1G
+      options:
+        network-manager: Neutron
+    neutron-gateway:
+      charm: neutron-gateway
+      constraints: mem=4G
+      options:
+        instance-mtu: 1300
+        bridge-mappings: physnet1:br-ex
+    cinder:
+      charm: cinder
+      options:
+        block-device: "None"
+        glance-api-version: 2
+      constraints": mem=1G
+    glance:
+      charm: glance
+      constraints: mem=1G
+    swift-proxy:
+      charm: swift-proxy
+      constraints: mem=1G
+      options:
+        zone-assignment: manual
+        replicas: 3
+        swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+    swift-storage-z1:
+      charm: swift-storage-z1
+      constraints: mem=1G
+      options:
+        zone: 1
+        block-device: vdb
+        overwrite: "true"
+    swift-storage-z2:
+      charm: swift-storage-z2
+      constraints: mem=1G
+      options:
+        zone: 2
+        block-device: vdb
+        overwrite: "true"
+    swift-storage-z3:
+      charm: swift-storage-z3
+      constraints: mem=1G
+      options:
+        zone: 3
+        block-device: vdb
+        overwrite: "true"
+    tempest:
+      charm: tempest
+      constraints: mem=1G
+  relations:
+    - [ keystone, mysql ]
+    - [ nova-cloud-controller, mysql ]
+    - [ nova-cloud-controller, rabbitmq-server ]
+    - [ nova-cloud-controller, glance ]
+    - [ nova-cloud-controller, keystone ]
+    - [ nova-compute, nova-cloud-controller ]
+    - [ nova-compute, mysql ]
+    - - nova-compute
+      - rabbitmq-server:amqp
+    - [ nova-compute, glance ]
+    - [ nova-compute, ceph-mon ]
+    - [ glance, mysql ]
+    - [ glance, keystone ]
+    - [ glance, ceph-mon ]
+    - [ ceph-mon, ceph-osd ]
+    - [ glance, "cinder:image-service" ]
+    - [ cinder, mysql ]
+    - [ cinder, rabbitmq-server ]
+    - [ cinder, nova-cloud-controller ]
+    - [ cinder, keystone ]
+    - [ cinder, ceph-mon ]
+    - [ neutron-gateway, nova-cloud-controller ]
+    - [ "openstack-dashboard:identity-service", keystone ]
+    - [ swift-proxy, keystone ]
+    - [ swift-proxy, swift-storage-z1 ]
+    - [ swift-proxy, swift-storage-z2 ]
+    - [ swift-proxy, swift-storage-z3 ]
+    - [ keystone, tempest ]
+ceilometer-mongodb:
+  services:
+    ceilometer:
+      charm: ceilometer
+      constraints: mem=1G
+    ceilometer-agent:
+      charm: ceilometer-agent
+    mongodb:
+      charm: mongodb
+      constraints: mem=1G
+  relations:
+    - - ceilometer
+      - keystone:identity-service
+    - - ceilometer
+      - keystone:identity-notifications
+    - [ ceilometer, rabbitmq-server ]
+    - [ ceilometer, mongodb ]
+    - [ ceilometer-agent, nova-compute ]
+    - [ ceilometer-agent, ceilometer ]
+charm-ceilometer-gnocchi:
+  services:
+    ceilometer:
+      charm: ceilometer
+      constraints: mem=1G
+    ceilometer-agent:
+      charm: ceilometer-agent
+    gnocchi:
+      charm: gnocchi
+    memcached:
+      charm: memcached
+  relations:
+    - - ceilometer
+      - keystone:identity-notifications
+    - [ ceilometer, rabbitmq-server ]
+    - [ ceilometer, gnocchi ]
+    - [ ceilometer-agent, nova-compute ]
+    - [ ceilometer-agent, ceilometer ]
+    - - ceph-mon
+      - gnocchi
+    - - gnocchi
+      - memcached
+    - - gnocchi
+      - ceilometer
+    - - gnocchi
+      - keystone
+    - - gnocchi
+      - mysql
+ceilometer-gnocchi:
+  inherits: [ charm-ceilometer-gnocchi]
+  relations:
+    - - ceilometer
+      - keystone:identity-credentials
+openstack-singlerabbit:
+  inherits: openstack-services
+  relations:
+    - [ "neutron-gateway:amqp", rabbitmq-server ]
+openstack-icehouse:
+  inherits: openstack-singlerabbit
+  services:
+    neutron-api:
+      charm: neutron-api
+      constraints: mem=1G
+      options:
+        neutron-security-groups: True
+        flat-network-providers: physnet1
+    neutron-openvswitch:
+      charm: neutron-openvswitch
+  relations:
+  - [ neutron-api, mysql ]
+  - [ neutron-api, rabbitmq-server ]
+  - [ neutron-api, nova-cloud-controller ]
+  - [ neutron-api, neutron-openvswitch ]
+  - [ neutron-api, keystone ]
+  - [ neutron-api, neutron-gateway ]
+  - [ neutron-openvswitch, nova-compute ]
+  - [ neutron-openvswitch, rabbitmq-server ]
+openstack-icehouse-msg-split:
+  inherits: openstack-services
+  services:
+    neutron-api:
+      charm: neutron-api
+      constraints: mem=1G
+      options:
+        neutron-security-groups: True
+    neutron-openvswitch:
+      charm: neutron-openvswitch
+    rabbitmq-server-neutron:
+      charm: rabbitmq-server
+      constraints: mem=1G
+  relations:
+  - [ neutron-api, mysql ]
+  - [ neutron-api, rabbitmq-server-neutron ]
+  - [ neutron-api, nova-cloud-controller ]
+  - [ neutron-api, neutron-openvswitch ]
+  - [ neutron-api, keystone ]
+  - [ neutron-api, neutron-gateway ]
+  - [ neutron-openvswitch, nova-compute ]
+  - [ neutron-openvswitch, rabbitmq-server-neutron ]
+  - [ "neutron-gateway:amqp-nova", rabbitmq-server ]
+  - [ "neutron-gateway:amqp", rabbitmq-server-neutron ]
+# icehouse
+precise-icehouse:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: precise
+  overrides:
+    openstack-origin: cloud:precise-icehouse
+    source: cloud:precise-updates/icehouse
+precise-icehouse-proposed:
+  inherits: precise-icehouse
+  overrides:
+    openstack-origin: cloud:precise-icehouse/proposed
+    source: cloud:precise-updates/icehouse
+precise-icehouse-staging:
+  inherits: precise-icehouse
+  overrides:
+    openstack-origin: ppa:ubuntu-cloud-archive/icehouse-staging
+    source: ppa:ubuntu-cloud-archive/icehouse-staging
+precise-icehouse-trunk:
+  inherits: precise-icehouse
+  overrides:
+    openstack-origin: ppa:openstack-ubuntu-testing/icehouse
+    source: ppa:openstack-ubuntu-testing/icehouse
+trusty-icehouse:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: trusty
+trusty-icehouse-msg-split:
+  inherits: [ openstack-icehouse-msg-split, ceilometer-mongodb ]
+  series: trusty
+trusty-icehouse-proposed:
+  inherits: trusty-icehouse
+  overrides:
+    source: proposed
+    openstack-origin: distro-proposed
+trusty-icehouse-trunk:
+  inherits: trusty-icehouse
+  overrides:
+    openstack-origin: ppa:openstack-ubuntu-testing/icehouse
+    source: ppa:openstack-ubuntu-testing/icehouse
+    offline-compression: "no"
+# kilo
+trusty-kilo:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: trusty
+  overrides:
+    openstack-origin: cloud:trusty-kilo
+    source: cloud:trusty-kilo
+trusty-kilo-proposed:
+  inherits: trusty-kilo
+  overrides:
+    openstack-origin: cloud:trusty-kilo/proposed
+    source: cloud:trusty-proposed/kilo
+trusty-kilo-staging:
+  inherits: trusty-kilo
+  overrides:
+    openstack-origin: ppa:ubuntu-cloud-archive/kilo-staging
+    source: ppa:ubuntu-cloud-archive/kilo-staging
+# liberty
+trusty-liberty:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: trusty
+  overrides:
+    openstack-origin: cloud:trusty-liberty
+    source: cloud:trusty-liberty
+trusty-liberty-proposed:
+  inherits: trusty-liberty
+  overrides:
+    openstack-origin: cloud:trusty-liberty/proposed
+    source: cloud:trusty-liberty/proposed
+trusty-liberty-staging:
+  inherits: trusty-liberty
+  overrides:
+    openstack-origin: ppa:ubuntu-cloud-archive/liberty-staging
+    source: ppa:ubuntu-cloud-archive/liberty-staging
+# mitaka
+trusty-mitaka:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: trusty
+  overrides:
+    openstack-origin: cloud:trusty-mitaka
+    source: cloud:trusty-mitaka
+trusty-mitaka-proposed:
+  inherits: trusty-mitaka
+  overrides:
+    openstack-origin: cloud:trusty-mitaka/proposed
+    source: cloud:trusty-proposed/mitaka
+trusty-mitaka-staging:
+  inherits: trusty-mitaka
+  overrides:
+    openstack-origin: ppa:ubuntu-cloud-archive/mitaka-staging
+    source: ppa:ubuntu-cloud-archive/mitaka-staging
+xenial-mitaka:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: xenial
+xenial-mitaka-proposed:
+  inherits: xenial-mitaka
+  overrides:
+    source: proposed
+    openstack-origin: distro-proposed
+# newton
+xenial-newton:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: xenial
+  overrides:
+    openstack-origin: cloud:xenial-newton
+    source: cloud:xenial-newton
+xenial-newton-proposed:
+  inherits: xenial-newton
+  overrides:
+    openstack-origin: cloud:xenial-newton/proposed
+    source: cloud:xenial-proposed/newton
+xenial-newton-staging:
+  inherits: xenial-newton
+  overrides:
+    openstack-origin: ppa:ubuntu-cloud-archive/newton-staging
+    source: ppa:ubuntu-cloud-archive/newton-staging
+# ocata
+xenial-ocata:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: xenial
+  overrides:
+    openstack-origin: cloud:xenial-ocata
+    source: cloud:xenial-ocata
+zesty-ocata:
+  inherits: [ openstack-icehouse, ceilometer-mongodb ]
+  series: zesty
+# pike
+xenial-pike:
+  inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
+  series: xenial
+  overrides:
+    openstack-origin: cloud:xenial-pike
+    source: cloud:xenial-pike
+artful-pike:
+  inherits: [ openstack-icehouse, ceilometer-mongodb, charm-ceilometer-gnocchi ]
+  series: artful

--- a/specs/full_stack/stable_deploy/mitaka/full.yaml
+++ b/specs/full_stack/stable_deploy/mitaka/full.yaml
@@ -1,1 +1,1 @@
-../../../../helper/bundles/full.yaml
+../../../../helper/bundles/full-osd-reformat-is-text.yaml

--- a/specs/full_stack/stable_deploy/newton/full.yaml
+++ b/specs/full_stack/stable_deploy/newton/full.yaml
@@ -1,1 +1,1 @@
-../../../../helper/bundles/full.yaml
+../../../../helper/bundles/full-osd-reformat-is-text.yaml

--- a/specs/full_stack/stable_deploy/ocata/full.yaml
+++ b/specs/full_stack/stable_deploy/ocata/full.yaml
@@ -1,1 +1,1 @@
-../../../../helper/bundles/full.yaml
+../../../../helper/bundles/full-osd-reformat-is-text.yaml

--- a/specs/full_stack/stable_deploy/pike/full.yaml
+++ b/specs/full_stack/stable_deploy/pike/full.yaml
@@ -1,1 +1,1 @@
-../../../../helper/bundles/full.yaml
+../../../../helper/bundles/full-osd-reformat-is-text.yaml


### PR DESCRIPTION
Basically a workaround for bug [1] in python-novaclient that
(particularly with ocata) sometimes generates a 400 error when trying to
list the current instances.

Also, some tweaks to various specs whilst manually running mojo specs.

[1] https://bugs.launchpad.net/python-novaclient/+bug/1772926