### PR TITLE
Fix designate-ha for removal of notification recs

### DIFF
--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -215,7 +215,6 @@ openstack-services-trusty-mitaka:
     - [ designate, neutron-api ]
     - [ designate, designate-hacluster ]
     # designate <-> nova-compute needed for legacy notifications
-    - [ designate, nova-compute ]
     - [ keystone, tempest ]
 openstack-services-xenial-mitaka:
   inherits: openstack-services-trusty-mitaka

--- a/helper/tests/expand_and_shrink_bind.py
+++ b/helper/tests/expand_and_shrink_bind.py
@@ -20,32 +20,17 @@ def main(argv):
     client = mojo_os_utils.get_designate_session_client(keystone_session)
     os_version = mojo_os_utils.get_current_os_versions('keystone')['keystone']
 
-    if os_version >= 'queens':
-        designate_api_version = 2
-        zone = mojo_os_utils.create_or_return_zone(
-            client,
-            TEST_DOMAIN,
-            TEST_DOMAIN_EMAIL)
-        rs = mojo_os_utils.create_or_return_recordset(
-            client,
-            zone['id'],
-            'www',
-            'A',
-            [TEST_RECORD[TEST_WWW_RECORD]])
-    else:
-        designate_api_version = 1
-
-        # Create test domain and record in test domain
-        domain = mojo_os_utils.create_designate_dns_domain(
-            client,
-            TEST_DOMAIN,
-            TEST_DOMAIN_EMAIL)
-        record = mojo_os_utils.create_designate_dns_record(
-            client,
-            domain.id,
-            TEST_WWW_RECORD,
-            "A",
-            TEST_RECORD[TEST_WWW_RECORD])
+    designate_api_version = 2
+    zone = mojo_os_utils.create_or_return_zone(
+        client,
+        TEST_DOMAIN,
+        TEST_DOMAIN_EMAIL)
+    rs = mojo_os_utils.create_or_return_recordset(
+        client,
+        zone['id'],
+        'www',
+        'A',
+        [TEST_RECORD[TEST_WWW_RECORD]])
 
     # Test record is in bind and designate
     mojo_os_utils.check_dns_entry(

--- a/helper/tests/validate_aodh.py
+++ b/helper/tests/validate_aodh.py
@@ -23,7 +23,7 @@ def main(argv):
         logging.info('Using server {} for aodh test'.format(server.name))
         server = nova_client.servers.find(name=server.name)
         logging.info('Deleting alarm {} if it exists'.format(alarm_name))
-        mojo_os_utils.delete_alarm(aodhc, alarm_name)
+        mojo_os_utils.delete_alarm(aodhc, alarm_name, cache_wait=True)
         logging.info('Creating alarm {}'.format(alarm_name))
         alarm_def = {
             'type': 'event',

--- a/helper/tests/validate_designate.py
+++ b/helper/tests/validate_designate.py
@@ -24,35 +24,11 @@ def main(argv):
     for server in nova_client.servers.list():
         for addr_info in server.addresses['private']:
             if addr_info['OS-EXT-IPS:type'] == 'floating':
-                mojo_os_utils.check_dns_entry_in_bind(
-                    addr_info['addr'],
-                    '{}.{}'.format(server.name, domain_name))
-            # Test legacy notifications based records
-            if addr_info['OS-EXT-IPS:type'] == 'fixed' and nova_domain:
-                keystone_client = mojo_os_utils.get_keystone_session_client(
-                    keystone_session)
-
-                record_ctxt = {
-                    'hostname': server.name,
-                    'zone': nova_domain}
-
-                target_project = overcloud_novarc.get(
-                    'OS_TENANT_NAME',
-                    overcloud_novarc.get('OS_PROJECT_NAME'))
-                for project in keystone_client.projects.list():
-                    if project.name == target_project:
-                        record_ctxt['project_id'] = project.id
-                        record_ctxt['tenant_id'] = project.id
-
-                record_format = mojo_utils.juju_get(
-                    'designate',
-                    'nova-record-format')
-                record_name = record_format % record_ctxt
-                mojo_os_utils.check_dns_entry_in_designate(
+                mojo_os_utils.check_dns_entry(
                     des_client,
                     addr_info['addr'],
-                    nova_domain,
-                    record_name=record_name)
+                    domain_name,
+                    '{}.{}'.format(server.name, domain_name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Remove designate <-> nova-compute relation which has gone from the charms
* Use designate v2 for all interations as all supported versions have it
* Add a cache_wait option to alarm deletion as aodh caches its alarms and
  will give spurious results.
* Stop testing notification based record creation
* Add logging on success to record tests to give a warm fuzzy glow