### PR TITLE
Tempest does not deploy on trusty

### DIFF
--- a/helper/bundles/dynamic-routing-next.yaml
+++ b/helper/bundles/dynamic-routing-next.yaml
@@ -209,8 +209,6 @@ openstack-services-trusty-mitaka:
     - [ designate, designate-bind ]
     - [ designate, memcached ]
     - [ designate, neutron-api ]
-    # designate <-> nova-compute needed for legacy notifications
-    - [ designate, nova-compute ]
     - [ keystone, tempest ]
 openstack-services-xenial-mitaka:
   inherits: openstack-services-trusty-mitaka

--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -90,9 +90,6 @@ openstack-services:
         zone: 3
         block-device: vdb
         overwrite: "true"
-    tempest:
-      charm: tempest
-      constraints: mem=1G
   relations:
     - [ keystone, mysql ]
     - [ nova-cloud-controller, mysql ]
@@ -121,7 +118,6 @@ openstack-services:
     - [ swift-proxy, swift-storage-z1 ]
     - [ swift-proxy, swift-storage-z2 ]
     - [ swift-proxy, swift-storage-z3 ]
-    - [ keystone, tempest ]
 ceilometer-mongodb:
   services:
     ceilometer:
@@ -315,6 +311,12 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: xenial
+  services:
+    tempest:
+      charm: tempest
+      constraints: mem=1G
+  relations:
+    - [ keystone, tempest ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:

--- a/helper/collect/collect-stable-trusty
+++ b/helper/collect/collect-stable-trusty
@@ -24,5 +24,3 @@ swift-storage-z2       cs:~openstack-charmers/swift-storage
 swift-storage-z3       cs:~openstack-charmers/swift-storage
 gnocchi                cs:~openstack-charmers/gnocchi
 memcached              cs:memcached
-# Tempest charm is basically never stable
-tempest                cs:~openstack-charmers-next/tempest


### PR DESCRIPTION
Update the bundle to only use tempest with >= xenial-mitaka.
Also remove the designate -> nova-compute relation in the dynamic
routing bundle.