### PR TITLE
Update bundles for barbican start point

### DIFF
--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -259,18 +259,8 @@ openstack-services-trusty-mitaka:
     - [ designate, designate-hacluster ]
     # designate <-> nova-compute needed for legacy notifications
     - [ keystone, tempest ]
-openstack-services-xenial-mitaka:
-  inherits: openstack-services-trusty-mitaka
-  services:
-    barbican:
-      charm: barbican
-      constraints: mem=1G
-  relations:
-    - [ barbican, rabbitmq-server ]
-    - [ barbican, mysql ]
-    - [ barbican, keystone ]
 openstack-services-xenial-ocata:
-  inherits: openstack-services-xenial-mitaka
+  inherits: openstack-services-trusty-mitaka
   services:
     gnocchi:
       charm: gnocchi
@@ -426,6 +416,14 @@ bionic-queens:
 # rocky
 bionic-rocky:
   inherits: bionic-queens
+  services:
+    barbican:
+      charm: barbican
+      constraints: mem=1G
+  relations:
+    - [ barbican, rabbitmq-server ]
+    - [ barbican, mysql ]
+    - [ barbican, keystone ]
   overrides:
     openstack-origin: cloud:bionic-rocky/proposed
     source: cloud:bionic-rocky/proposed

--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -284,6 +284,16 @@ openstack-services-xenial-queens:
   relations:
     - - ceilometer
       - keystone:identity-credentials
+openstack-services-bionic-rocky:
+  inherits: openstack-services-xenial-queens
+  services:
+    barbican:
+      charm: barbican
+      constraints: mem=1G
+  relations:
+    - [ barbican, rabbitmq-server ]
+    - [ barbican, mysql ]
+    - [ barbican, keystone ]
 # mitaka
 trusty-mitaka:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
@@ -415,18 +425,10 @@ bionic-queens:
     source: distro-proposed
 # rocky
 bionic-rocky:
-  inherits: bionic-queens
-  services:
-    barbican:
-      charm: barbican
-      constraints: mem=1G
-  relations:
-    - [ barbican, rabbitmq-server ]
-    - [ barbican, mysql ]
-    - [ barbican, keystone ]
+  inherits: [ openstack-services-bionic-rocky, charm-ceilometer-gnocchi ]
   overrides:
     openstack-origin: cloud:bionic-rocky/proposed
     source: cloud:bionic-rocky/proposed
 cosmic-rocky:
-  inherits: bionic-queens
+  inherits: [ openstack-services-bionic-rocky, charm-ceilometer-gnocchi ]
   series: cosmic

--- a/helper/bundles/dynamic-routing-next.yaml
+++ b/helper/bundles/dynamic-routing-next.yaml
@@ -243,18 +243,8 @@ openstack-services-trusty-mitaka:
     - [ designate, memcached ]
     - [ designate, neutron-api ]
     - [ keystone, tempest ]
-openstack-services-xenial-mitaka:
-  inherits: openstack-services-trusty-mitaka
-  services:
-    barbican:
-      charm: barbican
-      constraints: mem=1G
-  relations:
-    - [ barbican, rabbitmq-server ]
-    - [ barbican, mysql ]
-    - [ barbican, keystone ]
 openstack-services-xenial-ocata:
-  inherits: openstack-services-xenial-mitaka
+  inherits: openstack-services-trusty-mitaka
   services:
     gnocchi:
       charm: gnocchi
@@ -328,6 +318,14 @@ bionic-queens:
 # rocky
 bionic-rocky:
   inherits: bionic-queens
+  services:
+    barbican:
+      charm: barbican
+      constraints: mem=1G
+  relations:
+    - [ barbican, rabbitmq-server ]
+    - [ barbican, mysql ]
+    - [ barbican, keystone ]
   overrides:
     openstack-origin: cloud:bionic-rocky/proposed
     source: cloud:bionic-rocky/proposed

--- a/helper/bundles/dynamic-routing-next.yaml
+++ b/helper/bundles/dynamic-routing-next.yaml
@@ -268,6 +268,16 @@ openstack-services-xenial-queens:
   relations:
     - - ceilometer
       - keystone:identity-credentials
+openstack-services-bionic-rocky:
+  inherits: openstack-services-xenial-queens
+  services:
+    barbican:
+      charm: barbican
+      constraints: mem=1G
+  relations:
+    - [ barbican, rabbitmq-server ]
+    - [ barbican, mysql ]
+    - [ barbican, keystone ]
 # pike
 xenial-pike:
   inherits: [ openstack-services-xenial-ocata, dynamic-routing-services, ceilometer-mongodb, charm-ceilometer-gnocchi ]
@@ -317,18 +327,9 @@ bionic-queens:
     source: distro-proposed
 # rocky
 bionic-rocky:
-  inherits: bionic-queens
-  services:
-    barbican:
-      charm: barbican
-      constraints: mem=1G
-  relations:
-    - [ barbican, rabbitmq-server ]
-    - [ barbican, mysql ]
-    - [ barbican, keystone ]
   overrides:
     openstack-origin: cloud:bionic-rocky/proposed
     source: cloud:bionic-rocky/proposed
 cosmic-rocky:
-  inherits: bionic-queens
+  inherits: [ openstack-services-bionic-rocky, dynamic-routing-services, charm-ceilometer-gnocchi ]
   series: cosmic


### PR DESCRIPTION
Barbican and barbican-vault, when released to stable @ 18.11, will support only Rocky and later.