### PR TITLE
Ceilometer with a gnocchi backend schema action needs running

### DIFF
--- a/specs/full_stack/next_designate_ha/pike/ceilometer_setup.py
+++ b/specs/full_stack/next_designate_ha/pike/ceilometer_setup.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/ceilometer_setup.py

--- a/specs/full_stack/next_designate_ha/pike/manifest
+++ b/specs/full_stack/next_designate_ha/pike/manifest
@@ -22,6 +22,9 @@ script config=keystone_setup.py
 # Setup Designate
 script config=designate_setup.py
 
+# Setup ceilometer
+script config=ceilometer_setup.py
+
 # Launch instances on the overcloud
 verify config=simple_os_checks.py MACHINES='trusty:m1.small:2' CLOUDINIT_WAIT="600"
 

--- a/specs/full_stack/next_designate_ha/queens/ceilometer_setup.py
+++ b/specs/full_stack/next_designate_ha/queens/ceilometer_setup.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/ceilometer_setup.py

--- a/specs/full_stack/next_designate_ha/queens/manifest
+++ b/specs/full_stack/next_designate_ha/queens/manifest
@@ -22,6 +22,9 @@ script config=keystone_setup.py
 # Setup Designate
 script config=designate_setup.py
 
+# Setup ceilometer
+script config=ceilometer_setup.py
+
 # Launch instances on the overcloud
 verify config=simple_os_checks.py MACHINES='trusty:m1.small:2' CLOUDINIT_WAIT="600"
 

--- a/specs/full_stack/next_designate_ha/rocky/ceilometer_setup.py
+++ b/specs/full_stack/next_designate_ha/rocky/ceilometer_setup.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/ceilometer_setup.py

--- a/specs/full_stack/next_designate_ha/rocky/manifest
+++ b/specs/full_stack/next_designate_ha/rocky/manifest
@@ -22,6 +22,9 @@ script config=keystone_setup.py
 # Setup Designate
 script config=designate_setup.py
 
+# Setup ceilometer
+script config=ceilometer_setup.py
+
 # Launch instances on the overcloud
 verify config=simple_os_checks.py MACHINES='trusty:m1.small:2' CLOUDINIT_WAIT="600"
 

--- a/specs/full_stack/next_series_upgrade/queens/ceilometer_setup.py
+++ b/specs/full_stack/next_series_upgrade/queens/ceilometer_setup.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/ceilometer_setup.py

--- a/specs/full_stack/next_series_upgrade/queens/manifest
+++ b/specs/full_stack/next_series_upgrade/queens/manifest
@@ -23,6 +23,9 @@ script config=keystone_setup.py
 # Setup Designate
 script config=designate_setup.py
 
+# Setup ceilometer
+script config=ceilometer_setup.py
+
 # Launch instances on the overcloud
 verify config=simple_os_checks.py MACHINES='trusty:m1.small:2' CLOUDINIT_WAIT="600"
 


### PR DESCRIPTION
When ceilometer has a gnocchi backend the schema needs to be initialised via an action post-deployment.