### PR TITLE
Make bionic series explicit

### DIFF
--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -423,6 +423,7 @@ bionic-queens:
 # rocky
 bionic-rocky:
   inherits: [ openstack-services-bionic-rocky, charm-ceilometer-gnocchi ]
+  series: bionic
   overrides:
     openstack-origin: cloud:bionic-rocky/proposed
     source: cloud:bionic-rocky/proposed

--- a/helper/bundles/dynamic-routing-next.yaml
+++ b/helper/bundles/dynamic-routing-next.yaml
@@ -331,6 +331,8 @@ bionic-queens:
   series: bionic
 # rocky
 bionic-rocky:
+  inherits: [ openstack-services-xenial-queens, dynamic-routing-services, charm-ceilometer-gnocchi ]
+  series: bionic
   overrides:
     openstack-origin: cloud:bionic-rocky/proposed
     source: cloud:bionic-rocky/proposed


### PR DESCRIPTION
In bionic rocky tests juju-deployer is confused about which series is
being deployed. Make it explicit.