### PR TITLE
move memcached to openstack-charmers fork

### DIFF
--- a/helper/collect/collect-next-ha
+++ b/helper/collect/collect-next-ha
@@ -23,4 +23,4 @@ swift-storage-z1       cs:~openstack-charmers-next/swift-storage
 swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached

--- a/helper/collect/collect-next-reactive-xenial
+++ b/helper/collect/collect-next-reactive-xenial
@@ -26,6 +26,6 @@ gnocchi                cs:~openstack-charmers-next/gnocchi
 barbican               cs:~openstack-charmers-next/barbican
 designate-bind         cs:~openstack-charmers-next/designate-bind
 designate              cs:~openstack-charmers-next/designate
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached
 quagga                 cs:~openstack-charmers-next/quagga
 neutron-dynamic-routing  cs:~openstack-charmers-next/neutron-dynamic-routing

--- a/helper/collect/collect-next-trusty
+++ b/helper/collect/collect-next-trusty
@@ -24,4 +24,4 @@ swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 tempest                cs:~openstack-charmers-next/tempest
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached

--- a/helper/collect/collect-next-xenial
+++ b/helper/collect/collect-next-xenial
@@ -25,5 +25,5 @@ swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 tempest                cs:~openstack-charmers-next/tempest
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached
 vault                  cs:~openstack-charmers-next/vault

--- a/helper/collect/collect-stable-ha
+++ b/helper/collect/collect-stable-ha
@@ -23,4 +23,4 @@ swift-storage-z1       cs:~openstack-charmers/swift-storage
 swift-storage-z2       cs:~openstack-charmers/swift-storage
 swift-storage-z3       cs:~openstack-charmers/swift-storage
 gnocchi                cs:~openstack-charmers/gnocchi
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached

--- a/helper/collect/collect-stable-ha-trusty
+++ b/helper/collect/collect-stable-ha-trusty
@@ -24,4 +24,4 @@ swift-storage-z1       git://github.com/openstack/charm-swift-storage
 swift-storage-z2       git://github.com/openstack/charm-swift-storage
 swift-storage-z3       git://github.com/openstack/charm-swift-storage
 gnocchi                git://github.com/openstack/charm-gnocchi
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached

--- a/helper/collect/collect-stable-trusty
+++ b/helper/collect/collect-stable-trusty
@@ -1,4 +1,4 @@
-aodh                   cs:~openstack-charmers/aodh  
+aodh                   cs:~openstack-charmers/aodh
 ceilometer-agent       cs:~openstack-charmers/ceilometer-agent
 ceilometer             cs:~openstack-charmers/ceilometer
 ceph-mon               cs:~openstack-charmers/ceph-mon
@@ -23,4 +23,4 @@ swift-storage-z1       cs:~openstack-charmers/swift-storage
 swift-storage-z2       cs:~openstack-charmers/swift-storage
 swift-storage-z3       cs:~openstack-charmers/swift-storage
 gnocchi                cs:~openstack-charmers/gnocchi
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached

--- a/helper/collect/collect-stable-xenial
+++ b/helper/collect/collect-stable-xenial
@@ -1,4 +1,4 @@
-aodh                   cs:~openstack-charmers/aodh  
+aodh                   cs:~openstack-charmers/aodh
 ceilometer-agent       cs:~openstack-charmers/ceilometer-agent
 ceilometer             cs:~openstack-charmers/ceilometer
 ceph-mon               cs:~openstack-charmers/ceph-mon
@@ -23,6 +23,6 @@ swift-storage-z1       cs:~openstack-charmers/swift-storage
 swift-storage-z2       cs:~openstack-charmers/swift-storage
 swift-storage-z3       cs:~openstack-charmers/swift-storage
 gnocchi                cs:~openstack-charmers/gnocchi
-memcached              cs:memcached
+memcached              cs:~openstack-charmers/memcached
 # Tempest charm is basically never stable
 tempest                cs:~openstack-charmers-next/tempest


### PR DESCRIPTION
Per upstream release policy, the cs:~memcached charm will
only support the LTS releases of Ubuntu, so this retargets
our testing to an expanded charm with more series support