### PR TITLE
Ensure we end up with the ceilometer-agent <-> rabbit relation

### DIFF
--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -369,13 +369,13 @@ artful-pike:
     - [ cinder-ceph, nova-compute ]
 # queens
 xenial-queens:
-  inherits: [ openstack-icehouse, charm-ceilometer-gnocchi ]
+  inherits: [ openstack-services, ceilometer-gnocchi ]
   series: xenial
   overrides:
     openstack-origin: cloud:xenial-queens
     source: cloud:xenial-queens
 bionic-queens:
-  inherits: [ openstack-icehouse, charm-ceilometer-gnocchi ]
+  inherits:  [ xenial-queens ]
   series: bionic
 #rocky
 bionic-rocky:

--- a/helper/utils/mojo_utils.py
+++ b/helper/utils/mojo_utils.py
@@ -410,6 +410,8 @@ def upgrade_all_services(juju_status=None, switch=None):
                 juju_status['applications'][svc]['charm'])
             upgrade_service(svc, charm_name=charm_name, switch=switch)
             time.sleep(30)
+    cmd = ['juju', 'add-relation', 'ceilometer-agent:amqp', 'rabbitmq-server']
+    subprocess.call(cmd)
 
 
 # Begin upgrade code


### PR DESCRIPTION
After a charm upgrade from stable to next, we need to ensure that we have this missing relation