### PR TITLE
Stop testing rebooted gateway on xenial

### DIFF
--- a/helper/tests/test_vrrp_ha.py
+++ b/helper/tests/test_vrrp_ha.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import time
 import sys
 import utils.mojo_utils as mojo_utils
@@ -111,6 +112,7 @@ def main(argv):
     logging.info('Checking there are multiple L3 agents running tenant router')
     if len(l3_agents) != 2:
         raise Exception('Unexpected number of l3 agents')
+    series = os.environ.get("MOJO_SERIES")
     for agent in l3_agents:
         gateway_hostname = agent['host']
         gateway_server = under_novac.servers.find(name=gateway_hostname)
@@ -137,7 +139,12 @@ def main(argv):
         if not check_neutron_agent_states(clients['neutron'],
                                           gateway_hostname):
             raise Exception('Server agents failed to reach active state')
-
+        if series == "xenial":
+            logging.info(
+                "Concluding tests as rebooting a xenial guest can cause "
+                "network interfaces to be renamed which breaks the "
+                "gateway")
+            return
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))


### PR DESCRIPTION
In the vrrp tests limit the testing to checking connectivity
to the guest once the gateway housing the active router has been
shutdown. This omits testing that the shutdown gateway recovers
properly once it is brought back up. The reason for limiting the
tests is that when a xenial guest is rebooted the network
interface names may change which breaks the bridges. This issue
is specific to testing on top of OpenStack and should not occur
when using the maas provider.