### PR TITLE
Ensure bionic/queens inherits from openstack-icehouse + fix to mojo_utils.py

### DIFF
--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -369,7 +369,7 @@ artful-pike:
     - [ cinder-ceph, nova-compute ]
 # queens
 xenial-queens:
-  inherits: [ openstack-services, ceilometer-gnocchi ]
+  inherits: [ openstack-icehouse, ceilometer-gnocchi ]
   series: xenial
   overrides:
     openstack-origin: cloud:xenial-queens

--- a/helper/utils/mojo_utils.py
+++ b/helper/utils/mojo_utils.py
@@ -419,6 +419,7 @@ def upgrade_all_services(juju_status=None, switch=None):
             upgrade_service(svc, charm_name=charm_name, switch=switch)
             time.sleep(30)
     cmd = ['juju', 'add-relation', 'ceilometer-agent:amqp', 'rabbitmq-server']
+    subprocess.call(cmd)
     cmd = ['juju', 'add-relation', 'nova-cloud-controller', 'memcached']
     subprocess.call(cmd)
 


### PR DESCRIPTION
The inheritance in full.yaml needs to be from openstack-icehouse as
otherwise neutron-api is missed out of the deploy.

Also a fix to mojo_utils.py to ensure that the neutron-gateway to
rabbitmq-server relation.