### PR TITLE
Add cs:memcached charm to stable_to_next_ha scenario

### DIFF
--- a/helper/bundles/ha-upgrade-next.yaml
+++ b/helper/bundles/ha-upgrade-next.yaml
@@ -1,0 +1,39 @@
+# vim: set ts=2 et:
+memcached-services:
+  services:
+    memcached:
+      charm: memcached
+      constraints: mem=1G
+      num_units: 1
+trusty-memcached:
+  inherits: memcached-services
+  series: trusty
+trusty-mitaka-memcached:
+  inherits: trusty-memcached
+xenial-memcached:
+  inherits: memcached-services
+  series: xenial
+xenial-mitaka-memcached:
+  inherits: xenial-memcached
+xenial-newton-memcached:
+  inherits: xenial-memcached
+xenial-ocata-memcached:
+  inherits: xenial-memcached
+xenial-pike-memcached:
+  inherits: xenial-memcached
+xenial-queens-memcached:
+  inherits: xenial-memcached
+bionic-memcached:
+  inherits: memcached-services
+  series: bionic
+bionic-queens-memcached:
+  inherits: bionic-memcached
+bionic-rocky-memcached:
+  inherits: bionic-memcached
+# memcached charm is not released for cosmic or disco (at time of commit)
+#cosmic-memcacheed:
+#  inherits: memcached-services
+#  series: cosmic
+#disco-memcacheed:
+#  inherits: memcached-services
+#  series: disco

--- a/helper/collect/collect-next-ha
+++ b/helper/collect/collect-next-ha
@@ -23,4 +23,4 @@ swift-storage-z1       cs:~openstack-charmers-next/swift-storage
 swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:memcached

--- a/specs/full_stack/stable_to_next_ha/mitaka/ha-upgrade-next.yaml
+++ b/specs/full_stack/stable_to_next_ha/mitaka/ha-upgrade-next.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/ha-upgrade-next.yaml

--- a/specs/full_stack/stable_to_next_ha/mitaka/manifest
+++ b/specs/full_stack/stable_to_next_ha/mitaka/manifest
@@ -28,6 +28,10 @@ script config=wipe_charm_dir.py
 # Collect the next (devel) charm branches from Launchpad
 collect config=collect-next-ha
 
+# Deploy the memcached charm into existing system -- doesn't relate it to nova-cloud-controller
+# the relation is part of the upgrade-charm script
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=ha-upgrade-next.yaml delay=0 wait=False target=${MOJO_SERIES}-mitaka-memcached
+
 # Run upgrade-charm on all services
 script config=upgrade_all_services.py
 

--- a/specs/full_stack/stable_to_next_ha/newton/ha-upgrade-next.yaml
+++ b/specs/full_stack/stable_to_next_ha/newton/ha-upgrade-next.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/ha-upgrade-next.yaml

--- a/specs/full_stack/stable_to_next_ha/newton/manifest
+++ b/specs/full_stack/stable_to_next_ha/newton/manifest
@@ -28,6 +28,10 @@ script config=wipe_charm_dir.py
 # Collect the next (devel) charm branches from Launchpad
 collect config=collect-next-ha
 
+# Deploy the memcached charm into existing system -- doesn't relate it to nova-cloud-controller
+# the relation is part of the upgrade-charm script
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=ha-upgrade-next.yaml delay=0 wait=False target=${MOJO_SERIES}-newton-memcached
+
 # Run upgrade-charm on all services
 script config=upgrade_all_services.py
 

--- a/specs/full_stack/stable_to_next_ha/ocata/ha-upgrade-next.yaml
+++ b/specs/full_stack/stable_to_next_ha/ocata/ha-upgrade-next.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/ha-upgrade-next.yaml

--- a/specs/full_stack/stable_to_next_ha/ocata/manifest
+++ b/specs/full_stack/stable_to_next_ha/ocata/manifest
@@ -27,6 +27,10 @@ script config=wipe_charm_dir.py
 
 # Collect the next (devel) charm branches from Launchpad
 collect config=collect-next-ha
+#
+# Deploy the memcached charm into existing system -- doesn't relate it to nova-cloud-controller
+# the relation is part of the upgrade-charm script
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=ha-upgrade-next.yaml delay=0 wait=False target=${MOJO_SERIES}-ocata-memcached
 
 # Run upgrade-charm on all services
 script config=upgrade_all_services.py

--- a/specs/full_stack/stable_to_next_ha/pike/ha-upgrade-next.yaml
+++ b/specs/full_stack/stable_to_next_ha/pike/ha-upgrade-next.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/ha-upgrade-next.yaml

--- a/specs/full_stack/stable_to_next_ha/pike/manifest
+++ b/specs/full_stack/stable_to_next_ha/pike/manifest
@@ -28,6 +28,10 @@ script config=wipe_charm_dir.py
 # Collect the next (devel) charm branches from Launchpad
 collect config=collect-next-ha
 
+# Deploy the memcached charm into existing system -- doesn't relate it to nova-cloud-controller
+# the relation is part of the upgrade-charm script
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=ha-upgrade-next.yaml delay=0 wait=False target=${MOJO_SERIES}-pike-memcached
+
 # Run upgrade-charm on all services
 script config=upgrade_all_services.py
 

--- a/specs/full_stack/stable_to_next_ha/queens/ha-upgrade-next.yaml
+++ b/specs/full_stack/stable_to_next_ha/queens/ha-upgrade-next.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/ha-upgrade-next.yaml

--- a/specs/full_stack/stable_to_next_ha/queens/manifest
+++ b/specs/full_stack/stable_to_next_ha/queens/manifest
@@ -28,6 +28,10 @@ script config=wipe_charm_dir.py
 # Collect the next (devel) charm branches from Launchpad
 collect config=collect-next-ha
 
+# Deploy the memcached charm into existing system -- doesn't relate it to nova-cloud-controller
+# the relation is part of the upgrade-charm script
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=ha-upgrade-next.yaml delay=0 wait=False target=${MOJO_SERIES}-queens-memcached
+
 # Run upgrade-charm on all services
 script config=upgrade_all_services.py
 

--- a/specs/full_stack/stable_to_next_ha/rocky/ha-upgrade-next.yaml
+++ b/specs/full_stack/stable_to_next_ha/rocky/ha-upgrade-next.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/ha-upgrade-next.yaml

--- a/specs/full_stack/stable_to_next_ha/rocky/manifest
+++ b/specs/full_stack/stable_to_next_ha/rocky/manifest
@@ -28,6 +28,10 @@ script config=wipe_charm_dir.py
 # Collect the next (devel) charm branches from Launchpad
 collect config=collect-next-ha
 
+# Deploy the memcached charm into existing system -- doesn't relate it to nova-cloud-controller
+# the relation is part of the upgrade-charm script
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=ha-upgrade-next.yaml delay=0 wait=False target=${MOJO_SERIES}-rocky-memcached
+
 # Run upgrade-charm on all services
 script config=upgrade_all_services.py
 


### PR DESCRIPTION
This patchset updates the manifest to ensure that the next charms do get
memcached from the charmstore, that it gets collected, and therefore,
that it is available to be added during the upgrade-charm script

Fixes: #114