### PR TITLE
Remove NTP from the Ceph bundles

### DIFF
--- a/helper/bundles/ceph-base.yaml
+++ b/helper/bundles/ceph-base.yaml
@@ -3,8 +3,6 @@ base:
   relations:
   - - ceph-osd:mon
     - ceph-mon:osd
-  - - ntp:juju-info
-    - ceph-osd:juju-info
   services:
     ceph-mon:
       annotations:
@@ -22,12 +20,6 @@ base:
       num_units: 3
       storage:
         osd-devices:  cinder,40G
-    ntp:
-      annotations:
-        gui-x: '1000'
-        gui-y: '0'
-      charm: ntp
-      num_units: 0
 # icehouse
 trusty-icehouse:
   inherits: base

--- a/helper/bundles/charm-ceph.yaml
+++ b/helper/bundles/charm-ceph.yaml
@@ -3,8 +3,6 @@ base:
   relations:
   - - ceph-osd:mon
     - ceph:osd
-  - - ntp:juju-info
-    - ceph-osd:juju-info
   services:
     ceph:
       annotations:
@@ -26,12 +24,6 @@ base:
       num_units: 3
       storage:
         osd-devices:  cinder,40G
-    ntp:
-      annotations:
-        gui-x: '1000'
-        gui-y: '0'
-      charm: ntp
-      num_units: 0
 # icehouse
 trusty-icehouse:
   inherits: base

--- a/helper/collect/collect-ceph-default
+++ b/helper/collect/collect-ceph-default
@@ -1,4 +1,3 @@
 ceph                   cs:~openstack-charmers-next/ceph
 ceph-mon               cs:~openstack-charmers-next/ceph-mon
 ceph-osd               cs:~openstack-charmers-next/ceph-osd
-ntp                    cs:ntp


### PR DESCRIPTION
Ceph-OSD installs NTP as a part of the packaging, and
we are not doing any further customization of NTP.
Additionally, the NTP charm is maintained at a different
release cadence than the OpenStack charms which can
make testing difficult.