### PR TITLE
The Ceph packages install NTP so remove it from the bundle

### DIFF
--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -27,9 +27,6 @@ base-services:
       num_units: 3
       storage:
         osd-devices:  cinder,40G
-    ntp:
-      charm: ntp
-      num_units: 0
     keystone:
       charm: keystone
       constraints: mem=1G
@@ -152,7 +149,6 @@ base-services:
     - [ neutron-openvswitch, nova-compute ]
     - [ neutron-openvswitch, rabbitmq-server ]
     - [ ceph-osd, ceph-mon ]
-    - [ ntp, ceph-osd ]
 ceilometer-mongodb:
   services:
     ceilometer:


### PR DESCRIPTION
The NTP charm is useful if we arae customizing configuration
but we are using the default NTP configuration anyway, so
we can simplify our dependencies by removing it