### PR TITLE
Retry if instance has not appeared yet

### DIFF
--- a/helper/utils/mojo_os_utils.py
+++ b/helper/utils/mojo_os_utils.py
@@ -279,7 +279,7 @@ def wait_for_active(nova_client, vm_name, wait_time):
                 # element reduced by servers.findall
                 instance = nova_client.servers.findall(name=vm_name)[0]
                 break
-            except novaclient_exceptions.BadRequest:
+            except (novaclient_exceptions.BadRequest, IndexError):
                 count += 1
                 time.sleep(1)
         else:


### PR DESCRIPTION
If instance creation is still in progress openstack query may return
an empty list and hence IndexError is raised rather than BadRequest.