### PR TITLE
Use the fq namespace for the memcached charm

### DIFF
--- a/helper/collect/collect-next
+++ b/helper/collect/collect-next
@@ -24,4 +24,4 @@ swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 tempest                cs:~openstack-charmers-next/tempest
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached

--- a/helper/collect/collect-next-ha
+++ b/helper/collect/collect-next-ha
@@ -23,4 +23,4 @@ swift-storage-z1       cs:~openstack-charmers-next/swift-storage
 swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:memcached
+memcached              cs:~memcached-team/memcached

--- a/helper/collect/collect-next-ha-trusty
+++ b/helper/collect/collect-next-ha-trusty
@@ -24,4 +24,4 @@ swift-storage-z1       cs:~openstack-charmers-next/swift-storage
 swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:memcached
+memcached              cs:~memcached-team/memcached

--- a/helper/collect/collect-next-reactive-trusty
+++ b/helper/collect/collect-next-reactive-trusty
@@ -27,6 +27,6 @@ gnocchi                cs:~openstack-charmers-next/gnocchi
 barbican               cs:~openstack-charmers-next/barbican
 designate-bind         cs:~openstack-charmers-next/designate-bind
 designate              cs:~openstack-charmers-next/designate
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached
 quagga                 cs:~openstack-charmers-next/quagga
 neutron-dynamic-routing  cs:~openstack-charmers-next/neutron-dynamic-routing

--- a/helper/collect/collect-next-reactive-xenial
+++ b/helper/collect/collect-next-reactive-xenial
@@ -26,7 +26,7 @@ gnocchi                cs:~openstack-charmers-next/gnocchi
 barbican               cs:~openstack-charmers-next/barbican
 designate-bind         cs:~openstack-charmers-next/designate-bind
 designate              cs:~openstack-charmers-next/designate
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached
 quagga                 cs:~openstack-charmers-next/quagga
 neutron-dynamic-routing  cs:~openstack-charmers-next/neutron-dynamic-routing
 vault                  cs:~openstack-charmers-next/vault

--- a/helper/collect/collect-next-trusty
+++ b/helper/collect/collect-next-trusty
@@ -25,4 +25,4 @@ swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 tempest                cs:~openstack-charmers-next/tempest
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached

--- a/helper/collect/collect-next-xenial
+++ b/helper/collect/collect-next-xenial
@@ -25,5 +25,5 @@ swift-storage-z2       cs:~openstack-charmers-next/swift-storage
 swift-storage-z3       cs:~openstack-charmers-next/swift-storage
 tempest                cs:~openstack-charmers-next/tempest
 gnocchi                cs:~openstack-charmers-next/gnocchi
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached
 vault                  cs:~openstack-charmers-next/vault

--- a/helper/collect/collect-stable-ha
+++ b/helper/collect/collect-stable-ha
@@ -23,4 +23,4 @@ swift-storage-z1       cs:~openstack-charmers/swift-storage
 swift-storage-z2       cs:~openstack-charmers/swift-storage
 swift-storage-z3       cs:~openstack-charmers/swift-storage
 gnocchi                cs:~openstack-charmers/gnocchi
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached

--- a/helper/collect/collect-stable-trusty
+++ b/helper/collect/collect-stable-trusty
@@ -24,4 +24,4 @@ swift-storage-z1       cs:~openstack-charmers/swift-storage
 swift-storage-z2       cs:~openstack-charmers/swift-storage
 swift-storage-z3       cs:~openstack-charmers/swift-storage
 gnocchi                cs:~openstack-charmers/gnocchi
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached

--- a/helper/collect/collect-stable-xenial
+++ b/helper/collect/collect-stable-xenial
@@ -23,6 +23,6 @@ swift-storage-z1       cs:~openstack-charmers/swift-storage
 swift-storage-z2       cs:~openstack-charmers/swift-storage
 swift-storage-z3       cs:~openstack-charmers/swift-storage
 gnocchi                cs:~openstack-charmers/gnocchi
-memcached              cs:~openstack-charmers/memcached
+memcached              cs:~memcached-team/memcached
 # Tempest charm is basically never stable
 tempest                cs:~openstack-charmers-next/tempest


### PR DESCRIPTION
Previously, temp forks were used for interim series enablement.  Currently, the official charm contains the necessary series, although the CS: is experiencing promulgation issues on this charm.  Hence the explicit charm url.