### PR TITLE
Fix x->b series upgrade

### DIFF
--- a/helper/tests/test_obj_store.py
+++ b/helper/tests/test_obj_store.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import os
 import threading
 import hashlib
 import string
@@ -49,8 +50,17 @@ class ObjectPushPull(threading.Thread):
                 self.failures += 1
 
     def get_swiftclient(self):
-        keystone_session = openstack_utils.get_overcloud_keystone_session()
-        swift_client = mojo_os_utils.get_swift_session_client(keystone_session)
+        try:
+            cacert = os.path.join(
+                os.environ.get('MOJO_LOCAL_DIR'), 'cacert.pem')
+            os.stat(cacert)
+        except FileNotFoundError:
+            cacert = None
+        keystone_session = openstack_utils.get_overcloud_keystone_session(
+            verify=cacert)
+        swift_client = mojo_os_utils.get_swift_session_client(
+            keystone_session,
+            cacert=cacert)
         return swift_client
 
     def get_checkstring(self, fname):

--- a/helper/utils/mojo_os_utils.py
+++ b/helper/utils/mojo_os_utils.py
@@ -64,8 +64,8 @@ def get_swift_client(novarc_creds):
     return swiftclient.client.Connection(**swift_creds)
 
 
-def get_swift_session_client(session):
-    return swiftclient.client.Connection(session=session)
+def get_swift_session_client(session, cacert=None):
+    return swiftclient.client.Connection(session=session, cacert=cacert)
 
 
 def get_designate_session_client(session, all_tenants=True,

--- a/specs/full_stack/next_series_upgrade/queens/manifest
+++ b/specs/full_stack/next_series_upgrade/queens/manifest
@@ -10,6 +10,9 @@ build config=generate_certs.py
 # Use juju deployer with designate-next-ha.yaml bundle
 deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=designate-next-ha.yaml delay=0 wait=False target=${MOJO_SERIES}-queens
 
+# Setup vault
+script config=vault_setup.py
+
 # Setup ceilometer
 script config=ceilometer_setup.py
 

--- a/specs/full_stack/next_series_upgrade/queens/vault_setup.py
+++ b/specs/full_stack/next_series_upgrade/queens/vault_setup.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/vault_setup.py


### PR DESCRIPTION
Fixes for:

* Series upgrade was failing due to swift proxy requiring ssl and
  the client had no ssl support.
* Series upgrade was failing due to vault setup step missing from
  manifest