### PR TITLE
switch keystone uuid to fernet before upgrade

### DIFF
--- a/specs/full_stack/next_openstack_upgrade/queens/juju_set.py
+++ b/specs/full_stack/next_openstack_upgrade/queens/juju_set.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/juju_set.py

--- a/specs/full_stack/next_openstack_upgrade/queens/manifest
+++ b/specs/full_stack/next_openstack_upgrade/queens/manifest
@@ -19,6 +19,9 @@ script config=keystone_setup.py
 # Launch instances on the overcloud
 verify config=simple_os_checks.py MACHINES='trusty:m1.small:2' CLOUDINIT_WAIT="600"
 
+# Switch keystone from uuid to fernet
+script config=juju_set.py SERVICE='keystone' KV='token-provider=fernet' WAIT='True'
+
 # Upgrade Openstack
 script config=upgrade_openstack.py
 


### PR DESCRIPTION
change token-provider from uuid to fernet for queens before doing the upgrade to rocky