### PR TITLE
Add HA and SSL support prior to Pike

### DIFF
--- a/helper/bundles/next-ha-nossl.yaml
+++ b/helper/bundles/next-ha-nossl.yaml
@@ -1,13 +1,6 @@
-# Currently this is a "Designate HA" bundle, but it is the beginning of the Kitchen Sink.
-#
-# TODO:
-#         - Add SSL everywhere
-#         - Add HA everywhere
-#         - Add KSV3 everywhere
-#
-# Targeted only for the more modern sets of charms, thus the corresponding release
-# combos are limited to Trusty-Mitaka and later.  Releases earlier than Trusty-Mitaka
-# will be tested via legacy bundles as separate scenarios.
+# Targeted only for Mitaka and Newton. For later releases use a bundle
+# with SSL support from vault.
+
 base-services:
   services:
     mysql:
@@ -183,29 +176,6 @@ base-services:
       options:
         corosync_transport: unicast
         cluster_count: 3
-    vault:
-      charm: vault
-      constraints: mem=1G
-      num_units: 3
-      options:
-        vip: "{{ MOJO_OS_VIP10 }}"
-        ssl-ca: include-base64://{{local_dir}}/cacert.pem
-        ssl-cert: include-base64://{{local_dir}}/cert.pem
-        ssl-key: include-base64://{{local_dir}}/cert.key
-    vault-hacluster:
-      charm: hacluster
-      options:
-        corosync_transport: unicast
-        cluster_count: 3
-    easyrsa:
-      # Cannot be deployed locally from collect as resource is lost
-      charm: cs:~gnuoy/easyrsa-0
-      num_units: 1
-    etcd:
-      charm: etcd
-      num_units: 3
-      options:
-        channel: 3.1/stable
   relations:
     - [ keystone, mysql ]
     - [ "nova-cloud-controller:shared-db", mysql ]
@@ -248,24 +218,6 @@ base-services:
     - [ neutron-openvswitch, nova-compute ]
     - [ neutron-openvswitch, rabbitmq-server ]
     - [ ceph-osd, ceph-mon ]
-    - - vault:shared-db
-      - mysql:shared-db
-    - - keystone:certificates
-      - vault:certificates
-    - - neutron-api:certificates
-      - vault:certificates
-    - - nova-cloud-controller:certificates
-      - vault:certificates
-    - - swift-proxy:certificates
-      - vault:certificates
-    - - cinder:certificates
-      - vault:certificates
-    - - glance:certificates
-      - vault:certificates
-    - - rabbitmq-server:certificates
-      - vault:certificates
-    - - heat:certificates
-      - vault:certificates
     - [ mysql, mysql-hacluster ]
     - [ keystone, keystone-hacluster ]
     - [ nova-cloud-controller, nova-cc-hacluster ]
@@ -275,11 +227,6 @@ base-services:
     - [ swift-proxy, swift-hacluster ]
     - [ neutron-api, neutron-hacluster ]
     - [ heat, heat-hacluster ]
-    - [ vault, vault-hacluster ]
-    - - etcd:certificates
-      - easyrsa:client
-    - - etcd:db
-      - vault:etcd
 ceilometer-mongodb:
   services:
     ceilometer:
@@ -309,8 +256,6 @@ ceilometer-mongodb:
     - [ ceilometer-agent, ceilometer ]
     - [ "ceilometer-agent:amqp", rabbitmq-server ]
     - [ ceilometer, ceilometer-hacluster ]
-    - - ceilometer:certificates
-      - vault:certificates
 charm-ceilometer-gnocchi:
   services:
     ceilometer:
@@ -356,22 +301,9 @@ charm-ceilometer-gnocchi:
       - mysql
     - [ ceilometer, ceilometer-hacluster ]
     - [ gnocchi, gnocchi-hacluster ]
-    - - ceilometer:certificates
-      - vault:certificates
-    - - gnocchi:certificates
-      - vault:certificates
 ceilometer-gnocchi:
   inherits: [ charm-ceilometer-gnocchi]
   relations:
-dynamic-routing-services:
-  services:
-    neutron-dynamic-routing:
-      charm: neutron-dynamic-routing
-    quagga:
-      charm: quagga
-  relations:
-    - [ neutron-dynamic-routing, rabbitmq-server ]
-    - [ neutron-dynamic-routing, quagga ]
 openstack-services-trusty-mitaka:
   inherits: base-services
   services:
@@ -405,9 +337,6 @@ openstack-services-trusty-mitaka:
     designate-bind:
       num_units: 3
       charm: designate-bind
-    tempest:
-      charm: tempest
-      constraints: mem=1G
   relations:
     - [ aodh, rabbitmq-server ]
     - [ aodh, mysql ]
@@ -421,46 +350,14 @@ openstack-services-trusty-mitaka:
     - [ designate, neutron-api ]
     - [ designate, designate-hacluster ]
     # designate <-> nova-compute needed for legacy notifications
-    - [ keystone, tempest ]
-    - - aodh:certificates
-      - vault:certificates
-    - - designate:certificates
-      - vault:certificates
-openstack-services-xenial-ocata:
+openstack-services-xenial-mitaka:
   inherits: openstack-services-trusty-mitaka
   services:
-    gnocchi:
-      charm: gnocchi
-  relations:
-    - [ gnocchi, ceph-mon ]
-    - [ gnocchi, mysql ]
-    - [ gnocchi, rabbitmq-server ]
-    - [ gnocchi, memcached ]
-    - [ gnocchi, ceilometer ]
-    - [ gnocchi, keystone ]
-    - [ cinder-ceph, nova-compute ]
-    - - gnocchi:certificates
-      - vault:certificates
-openstack-services-xenial-queens:
-  inherits: openstack-services-xenial-ocata
-  overrides:
-    nova-domain: ''
-    neutron-domain: ''
-    nova-domain-email: ''
-    neutron-domain-email: ''
-  relations:
-    - - ceilometer
-      - keystone:identity-credentials
-openstack-services-bionic-rocky:
-  inherits: openstack-services-xenial-queens
-  services:
-    barbican:
-      charm: barbican
+    tempest:
+      charm: tempest
       constraints: mem=1G
   relations:
-    - [ barbican, rabbitmq-server ]
-    - [ barbican, mysql ]
-    - [ barbican, keystone ]
+    - [ keystone, tempest ]
 # mitaka
 trusty-mitaka:
   inherits: [ openstack-services-trusty-mitaka, ceilometer-mongodb ]
@@ -468,174 +365,13 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
-trusty-mitaka-proposed:
-  inherits: trusty-mitaka
-  overrides:
-    openstack-origin: cloud:trusty-mitaka/proposed
-    source: cloud:trusty-mitaka/proposed
-trusty-mitaka-staging:
-  inherits: trusty-mitaka
-  overrides:
-    openstack-origin: ppa:ubuntu-cloud-archive/mitaka-staging
-    source: ppa:ubuntu-cloud-archive/mitaka-staging
 xenial-mitaka:
-  inherits: [ openstack-services-trusty-mitaka, ceilometer-mongodb ]
+  inherits: [ openstack-services-xenial-mitaka, ceilometer-mongodb ]
   series: xenial
-xenial-mitaka-proposed:
-  inherits: xenial-mitaka
-  overrides:
-    source: proposed
-    openstack-origin: distro-proposed
 # newton
 xenial-newton:
-  inherits: [ openstack-services-trusty-mitaka, ceilometer-mongodb ]
+  inherits: [ openstack-services-xenial-mitaka, ceilometer-mongodb ]
   series: xenial
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
-xenial-newton-proposed:
-  inherits: xenial-newton
-  overrides:
-    openstack-origin: cloud:xenial-newton/proposed
-    source: cloud:xenial-newton/proposed
-xenial-newton-staging:
-  inherits: xenial-newton
-  overrides:
-    openstack-origin: ppa:ubuntu-cloud-archive/newton-staging
-    source: ppa:ubuntu-cloud-archive/newton-staging
-xenial-newton-branch:
-  inherits: xenial-newton
-  overrides:
-    openstack-origin: ppa:openstack-ubuntu-testing/newton
-    source: ppa:openstack-ubuntu-testing/newton
-# ocata
-xenial-ocata:
-  inherits: [ openstack-services-xenial-ocata, ceilometer-mongodb ]
-  series: xenial
-  overrides:
-    openstack-origin: cloud:xenial-ocata
-    source: cloud:xenial-ocata
-xenial-ocata-proposed:
-  inherits: xenial-ocata
-  overrides:
-    openstack-origin: cloud:xenial-ocata/proposed
-    source: cloud:xenial-ocata/proposed
-xenial-ocata-staging:
-  inherits: xenial-ocata
-  overrides:
-    openstack-origin: ppa:ubuntu-cloud-archive/ocata-staging
-    source: ppa:ubuntu-cloud-archive/ocata-staging
-xenial-ocata-branch:
-  inherits: xenial-ocata
-  overrides:
-    openstack-origin: ppa:openstack-ubuntu-testing/ocata
-    source: ppa:openstack-ubuntu-testing/ocata
-zesty-ocata:
-  inherits: [ openstack-services-xenial-ocata, ceilometer-mongodb ]
-  series: zesty
-zesty-ocata-proposed:
-  inherits: zesty-ocata
-  overrides:
-    source: proposed
-    openstack-origin: distro-proposed
-zesty-ocata-branch:
-  inherits: zesty-ocata
-  overrides:
-    openstack-origin: ppa:openstack-ubuntu-testing/ocata
-    source: ppa:openstack-ubuntu-testing/ocata
-# pike
-xenial-pike:
-  inherits: [ openstack-services-xenial-ocata, ceilometer-mongodb, charm-ceilometer-gnocchi ]
-  series: xenial
-  overrides:
-    openstack-origin: cloud:xenial-pike
-    source: cloud:xenial-pike
-xenial-pike-proposed:
-  inherits: xenial-pike
-  overrides:
-    openstack-origin: cloud:xenial-pike/proposed
-    source: cloud:xenial-pike/proposed
-xenial-pike-staging:
-  inherits: xenial-pike
-  overrides:
-    openstack-origin: ppa:ubuntu-cloud-archive/pike-staging
-    source: ppa:ubuntu-cloud-archive/pike-staging
-xenial-pike-branch:
-  inherits: xenial-pike
-  overrides:
-    openstack-origin: ppa:openstack-ubuntu-testing/pike
-    source: ppa:openstack-ubuntu-testing/pike
-artful-pike:
-  inherits: [ openstack-services-xenial-ocata, ceilometer-mongodb, charm-ceilometer-gnocchi ]
-  series: artful
-artful-pike-proposed:
-  inherits: artful-pike
-  overrides:
-    source: proposed
-    openstack-origin: distro-proposed
-artful-pike-branch:
-  inherits: artful-pike
-  overrides:
-    openstack-origin: ppa:openstack-ubuntu-testing/pike
-    source: ppa:openstack-ubuntu-testing/pike
-xenial-queens:
-  inherits: [ openstack-services-xenial-queens, charm-ceilometer-gnocchi ]
-  series: xenial
-  overrides:
-    openstack-origin: cloud:xenial-queens
-    source: cloud:xenial-queens
-bionic-queens:
-  inherits: [ openstack-services-xenial-queens, charm-ceilometer-gnocchi ]
-  series: bionic
-# rocky
-bionic-rocky:
-  inherits: [ openstack-services-bionic-rocky, charm-ceilometer-gnocchi ]
-  series: bionic
-  overrides:
-    openstack-origin: cloud:bionic-rocky
-    source: cloud:bionic-rocky
-cosmic-rocky:
-  inherits: [ openstack-services-bionic-rocky, charm-ceilometer-gnocchi ]
-  series: cosmic
-  overrides:
-    openstack-origin: distro
-    source: distro
-# stein
-bionic-stein:
-  inherits: [ bionic-rocky ]
-  series: bionic
-  overrides:
-    openstack-origin: cloud:bionic-stein
-    source: cloud:bionic-stein
-disco-stein:
-  inherits: [ bionic-rocky ]
-  series: disco
-  overrides:
-    # Use distro-proposed until bug #1834565 is fixed in disco.
-    openstack-origin: distro-proposed
-    source: distro
-# train
-bionic-train:
-  inherits: [ bionic-rocky ]
-  series: bionic
-  services:
-    placement:
-      charm: placement
-      constraints: mem=1G
-      num_units: 3
-      options:
-        vip: "{{ MOJO_OS_VIP15 }}"
-    placement-hacluster:
-      charm: hacluster
-      options:
-        corosync_transport: unicast
-        cluster_count: 3
-  overrides:
-    openstack-origin: cloud:bionic-train
-    source: cloud:bionic-train
-  relations:
-    - [ placement, nova-cloud-controller ]
-    - [ placement, mysql ]
-    - [ placement, keystone ]
-    - [ placement, vault ]
-    - [ placement, placement-hacluster ]

--- a/helper/setup/add-certs.py
+++ b/helper/setup/add-certs.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+import base64
+import copy
+import logging
+import os
+import zaza.openstack.utilities.cert
+from zaza.openstack.utilities import (
+    cli as cli_utils,
+    openstack,
+)
+from zaza import model
+
+ISSUER_NAME = 'OSCI'
+CERT_DIR = os.environ.get('MOJO_LOCAL_DIR')
+
+
+def write_cert(path, filename, data, mode=0o600):
+    """
+    Helper function for writing certificate data to disk.
+
+    :param path: Directory file should be put in
+    :type path: str
+    :param filename: Name of file
+    :type filename: str
+    :param data: Data to write
+    :type data: any
+    :param mode: Create mode (permissions) of file
+    :type mode: Octal(int)
+    """
+    with os.fdopen(os.open(os.path.join(path, filename),
+                           os.O_WRONLY | os.O_CREAT, mode), 'wb') as f:
+        f.write(data)
+
+
+def create_certs(application_name, ip, issuer_name, signing_key):
+    """Generate a certificate for with the given info and store it.
+
+    Generate a certificate for with the given info and write it to disk.
+
+    :param application_name: Name of application, used to derive path to store
+                             artefacts.
+    :type application_name: str
+    :param ip: IP address that service will be accessed via.
+    :type ip: str
+    :param issuer_name: Name to be used as cert issuer.
+    :type issuer_name: str
+    :param signing_key: Key to sign cert with.
+    :type signing_key: str
+    """
+    logging.info("Creating cert for {}".format(application_name))
+    # The IP is used as the CN for backward compatability and as an
+    # alternative_name for forward comapability.
+    (key, cert) = zaza.openstack.utilities.cert.generate_cert(
+        ip,
+        issuer_name=ISSUER_NAME,
+        alternative_names=[ip],
+        signing_key=signing_key)
+    APP_CERT_DIR = os.path.join(CERT_DIR, application_name)
+    if not os.path.exists(APP_CERT_DIR):
+        os.makedirs(APP_CERT_DIR)
+    write_cert(APP_CERT_DIR, 'cert.pem', cert)
+    write_cert(APP_CERT_DIR, 'cert.key', key)
+
+
+def apply_certs(application_name):
+    """Read certs from disk and apply them to runninch charms.
+
+    :param application_name: Name of application, used to derive path to store
+                             artefacts.
+    :type application_name: str
+    """
+    APP_CERT_DIR = os.path.join(CERT_DIR, application_name)
+    ssl_options = [
+        ('ssl_ca', os.path.join(CERT_DIR, 'cacert.pem')),
+        ('ssl_cert', os.path.join(APP_CERT_DIR, 'cert.pem')),
+        ('ssl_key', os.path.join(APP_CERT_DIR, 'cert.key'))]
+    charm_config = {}
+    for (charm_option, ssl_file) in ssl_options:
+        with open(ssl_file, 'rb') as f:
+            ssl_data = f.read()
+        charm_config[charm_option] = base64.b64encode(ssl_data).decode('utf8')
+    model.set_application_config(
+        application_name,
+        configuration=charm_config)
+
+
+def create_ca():
+    """Create a CA
+
+    :returns: A tuple of CA key and cert.
+    :rtype: (str, str)
+    """
+    (cakey, cacert) = zaza.openstack.utilities.cert.generate_cert(
+        ISSUER_NAME,
+        generate_ca=True)
+    write_cert(CERT_DIR, 'cacert.pem', cacert)
+    write_cert(CERT_DIR, 'ca.key', cakey)
+    return (cakey, cacert)
+
+
+def encrypt_vip_endpoints():
+    """Apply certs and keys to all charms that support them."""
+    (cakey, cacert) = create_ca()
+    ssl_vip_keys = ['vip', 'ssl_ca', 'ssl_cert', 'ssl_key']
+    status = model.get_status()
+    for application_name in status.applications.keys():
+        app_config = model.get_application_config(application_name)
+        if all(k in app_config for k in ssl_vip_keys):
+            cn = app_config['vip'].get('value')
+            # If there is no vip check if its a non-ha deploy.
+            if not cn:
+                units = model.get_units(application_name)
+                if len(units) == 1:
+                    cn = units[0].public_address
+            if cn:
+                create_certs(
+                    application_name,
+                    cn,
+                    ISSUER_NAME,
+                    cakey)
+                apply_certs(application_name)
+    model.block_until_all_units_idle()
+
+
+if __name__ == "__main__":
+    cli_utils.setup_logging()
+    os_version = openstack.get_current_os_versions(
+        'designate').get('designate')
+    wl_statuses = copy.deepcopy(openstack.WORKLOAD_STATUS_EXCEPTIONS)
+    if os_version <= 'pike':
+        # Remove the memcached relation to disable designate. This is a
+        # workaround for Bug #1848307
+        logging.info("Removing designate memcached relation")
+        model.remove_relation(
+            'designate',
+            'coordinator-memcached',
+            'memcached:cache')
+        wl_statuses['designate'] = {
+            'workload-status-message': """'coordinator-memcached' missing""",
+            'workload-status': 'blocked'}
+    model.wait_for_application_states(
+        states=wl_statuses)
+    encrypt_vip_endpoints()
+    model.block_until_all_units_idle()
+    if os_version <= 'pike':
+        logging.info("Restoring designate memcached relation")
+        model.add_relation(
+            'designate',
+            'coordinator-memcached',
+            'memcached:cache')
+        del wl_statuses['designate']
+        model.wait_for_application_states(
+            states=wl_statuses)

--- a/helper/setup/vault_setup.py
+++ b/helper/setup/vault_setup.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     wl_statuses = copy.deepcopy(openstack.WORKLOAD_STATUS_EXCEPTIONS)
     os_version = openstack.get_current_os_versions(
         'designate').get('designate')
-    if os_version == 'pike':
+    if os_version <= 'pike':
         # Remove the memcached relation to disable designate. This is a
         # workaround for Bug #1848307
         logging.info("Removing designate memcached relation")
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         cacert.decode().strip())
     model.wait_for_application_states(
         states=wl_statuses)
-    if os_version == 'pike':
+    if os_version <= 'pike':
         logging.info("Restoring designate memcached relation")
         model.add_relation(
             'designate',

--- a/helper/tests/expand_and_shrink_bind.py
+++ b/helper/tests/expand_and_shrink_bind.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import sys
 import utils.mojo_utils as mojo_utils
 import utils.mojo_os_utils as mojo_os_utils
@@ -18,7 +19,13 @@ TEST_RECORD = {TEST_WWW_RECORD: '10.0.0.23'}
 def main(argv):
     cli_utils.setup_logging()
     # Setup client
-    keystone_session = openstack_utils.get_overcloud_keystone_session()
+    try:
+        cacert = os.path.join(os.environ.get('MOJO_LOCAL_DIR'), 'cacert.pem')
+        os.stat(cacert)
+    except FileNotFoundError:
+        cacert = None
+    keystone_session = openstack_utils.get_overcloud_keystone_session(
+        verify=cacert)
     os_version = openstack_utils.get_current_os_versions(
         'keystone')['keystone']
 

--- a/helper/tests/validate_aodh.py
+++ b/helper/tests/validate_aodh.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import os
 import sys
 import time
 import utils.mojo_os_utils as mojo_os_utils
@@ -12,7 +13,13 @@ from zaza.openstack.utilities import (
 
 def main(argv):
     cli_utils.setup_logging()
-    keystone_session = openstack_utils.get_overcloud_keystone_session()
+    try:
+        cacert = os.path.join(os.environ.get('MOJO_LOCAL_DIR'), 'cacert.pem')
+        os.stat(cacert)
+    except FileNotFoundError:
+        cacert = None
+    keystone_session = openstack_utils.get_overcloud_keystone_session(
+        verify=cacert)
     aodhc = mojo_os_utils.get_aodh_session_client(keystone_session)
     nova_client = openstack_utils.get_nova_session_client(keystone_session)
 

--- a/helper/tests/validate_designate.py
+++ b/helper/tests/validate_designate.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import os
 import sys
 import utils.mojo_os_utils as mojo_os_utils
 
@@ -11,6 +12,11 @@ from zaza.openstack.utilities import (
 
 def main(argv):
     cli_utils.setup_logging()
+    try:
+        cacert = os.path.join(os.environ.get('MOJO_LOCAL_DIR'), 'cacert.pem')
+        os.stat(cacert)
+    except FileNotFoundError:
+        cacert = None
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--domain_name', help='DNS Domain Name. '
                                                     'Must end in a .',
@@ -24,7 +30,8 @@ def main(argv):
         designate_api = '2'
     else:
         designate_api = '1'
-    keystone_session = openstack_utils.get_overcloud_keystone_session()
+    keystone_session = openstack_utils.get_overcloud_keystone_session(
+        verify=cacert)
 
     nova_client = openstack_utils.get_nova_session_client(keystone_session)
     des_client = mojo_os_utils.get_designate_session_client(

--- a/specs/full_stack/next_designate_ha/mitaka/add-certs.py
+++ b/specs/full_stack/next_designate_ha/mitaka/add-certs.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/add-certs.py

--- a/specs/full_stack/next_designate_ha/mitaka/designate-next-ha-nossl.yaml
+++ b/specs/full_stack/next_designate_ha/mitaka/designate-next-ha-nossl.yaml
@@ -1,1 +1,0 @@
-../../../../helper/bundles/designate-next-ha-nossl.yaml

--- a/specs/full_stack/next_designate_ha/mitaka/manifest
+++ b/specs/full_stack/next_designate_ha/mitaka/manifest
@@ -5,7 +5,13 @@ script config=preflight.py
 collect config=collect-next-reactive-${MOJO_SERIES}
 
 # Use juju deployer with designate-next-ha.yaml bundle
-deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=designate-next-ha-nossl.yaml delay=0 wait=False target=${MOJO_SERIES}-mitaka
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=next-ha-nossl.yaml delay=0 wait=False target=${MOJO_SERIES}-mitaka
+
+# Apply certs
+script config=add-certs.py
+
+# Restart nova-compute (Bug #1826382)
+script config=restart_nova_compute.py
 
 # Check juju statuses are green and that hooks have finished
 verify config=check_juju.py

--- a/specs/full_stack/next_designate_ha/mitaka/next-ha-nossl.yaml
+++ b/specs/full_stack/next_designate_ha/mitaka/next-ha-nossl.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/next-ha-nossl.yaml

--- a/specs/full_stack/next_designate_ha/mitaka/restart_nova_compute.py
+++ b/specs/full_stack/next_designate_ha/mitaka/restart_nova_compute.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/restart_nova_compute.py

--- a/specs/full_stack/next_designate_ha/newton/add-certs.py
+++ b/specs/full_stack/next_designate_ha/newton/add-certs.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/add-certs.py

--- a/specs/full_stack/next_designate_ha/newton/designate-next-ha-nossl.yaml
+++ b/specs/full_stack/next_designate_ha/newton/designate-next-ha-nossl.yaml
@@ -1,1 +1,0 @@
-../../../../helper/bundles/designate-next-ha-nossl.yaml

--- a/specs/full_stack/next_designate_ha/newton/manifest
+++ b/specs/full_stack/next_designate_ha/newton/manifest
@@ -5,7 +5,13 @@ script config=preflight.py
 collect config=collect-next-reactive-${MOJO_SERIES}
 
 # Use juju deployer with designate-next-ha.yaml bundle
-deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=designate-next-ha-nossl.yaml delay=0 wait=False target=${MOJO_SERIES}-newton
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=next-ha-nossl.yaml delay=0 wait=False target=${MOJO_SERIES}-newton
+
+# Apply certs
+script config=add-certs.py
+
+# Restart nova-compute (Bug #1826382)
+script config=restart_nova_compute.py
 
 # Check juju statuses are green and that hooks have finished
 verify config=check_juju.py

--- a/specs/full_stack/next_designate_ha/newton/next-ha-nossl.yaml
+++ b/specs/full_stack/next_designate_ha/newton/next-ha-nossl.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/next-ha-nossl.yaml

--- a/specs/full_stack/next_designate_ha/newton/restart_nova_compute.py
+++ b/specs/full_stack/next_designate_ha/newton/restart_nova_compute.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/restart_nova_compute.py

--- a/specs/full_stack/next_designate_ha/ocata/designate-next-ha-nossl.yaml
+++ b/specs/full_stack/next_designate_ha/ocata/designate-next-ha-nossl.yaml
@@ -1,1 +1,0 @@
-../../../../helper/bundles/designate-next-ha-nossl.yaml

--- a/specs/full_stack/next_designate_ha/ocata/designate-next-ha.yaml
+++ b/specs/full_stack/next_designate_ha/ocata/designate-next-ha.yaml
@@ -1,0 +1,1 @@
+../../../../helper/bundles/designate-next-ha.yaml

--- a/specs/full_stack/next_designate_ha/ocata/generate_certs.py
+++ b/specs/full_stack/next_designate_ha/ocata/generate_certs.py
@@ -1,0 +1,1 @@
+../../../../helper/build/generate_certs.py

--- a/specs/full_stack/next_designate_ha/ocata/manifest
+++ b/specs/full_stack/next_designate_ha/ocata/manifest
@@ -4,8 +4,17 @@ script config=preflight.py
 # Collect the charm branches from Launchpad
 collect config=collect-next-reactive-${MOJO_SERIES}
 
+# Prepare artefacts required by the bundle
+build config=generate_certs.py
+
 # Use juju deployer with designate-next-ha.yaml bundle
-deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=designate-next-ha-nossl.yaml delay=0 wait=False target=${MOJO_SERIES}-ocata
+deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=designate-next-ha.yaml delay=0 wait=False target=${MOJO_SERIES}-ocata
+
+# Setup vault
+script config=vault_setup.py
+
+# Restart nova-compute (Bug #1826382)
+script config=restart_nova_compute.py
 
 # Setup ceilometer
 script config=ceilometer_setup.py
@@ -24,6 +33,9 @@ script config=keystone_setup.py
 
 # Setup Designate
 script config=designate_setup.py
+
+# Setup ceilometer
+script config=ceilometer_setup.py
 
 # Launch instances on the overcloud
 verify config=simple_os_checks.py MACHINES='trusty:m1.small:2' CLOUDINIT_WAIT="600"

--- a/specs/full_stack/next_designate_ha/ocata/restart_nova_compute.py
+++ b/specs/full_stack/next_designate_ha/ocata/restart_nova_compute.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/restart_nova_compute.py

--- a/specs/full_stack/next_designate_ha/ocata/vault_setup.py
+++ b/specs/full_stack/next_designate_ha/ocata/vault_setup.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/vault_setup.py


### PR DESCRIPTION
This adds HA and SSL support to Mitaka, Newton and Ocata.

A limitation in Newton and earlier means that the IP SANS part
of cerificates is ignored. The impact of this is that neither
vault nor pre-deploy certificate generation will work. The Vault
generated certificates use IP SANS for the vip and the pre-deploy
generated certificates work by creating IP SANS entries for all
IPs in a network range of which the VIP is one. To work around this
Mitaka and Newton have there certificates generated and applied
straight after deployment. This is not ideal but I think it is a
reasonable compramise.

Additional Fixes for Mitaka -> Ocata:

* Add missing gnocchi <-> vault relation
* New bundle for use with Mitaka and Newton that does a full HA
  deploy without SSL as SSL is added afterwards
* Ensure designate workaround for vault is applied to Ocata
* expand_and_shrink_bindpy, validate_aodh.py and
  validate_designate.pya all needed fixes to pickup the local CA.