### PR TITLE
Stop trusty-mitaka-ha target from using proposed

### DIFF
--- a/helper/bundles/ha-next.yaml
+++ b/helper/bundles/ha-next.yaml
@@ -301,7 +301,7 @@ trusty-mitaka-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: trusty
   overrides:
-    openstack-origin: cloud:trusty-mitaka/proposed
+    openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
 trusty-mitaka-proposed:
   inherits: [ openstack-services, ceilometer-mongodb ]


### PR DESCRIPTION
The trusty-mitaka-ha target in the ha-next.yaml was incorrectly
using the proposed pocket. The trusty-mitaka-proposed is already
available if proposed is required.