### PR TITLE
Stop sleeping in the charm upgrade test

### DIFF
--- a/helper/setup/upgrade_all_services.py
+++ b/helper/setup/upgrade_all_services.py
@@ -23,9 +23,9 @@ def main(argv):
         "Waiting for units to begin executing upgrade of base services")
     zaza.model.wait_for_agent_status(status='executing')
     logging.info("Waiting for units to be idle")
+    zaza.model.block_until_all_units_idle()
 
     logging.info("Upgrading remaining services")
-    zaza.model.block_until_all_units_idle()
     logging.info(
         "Waiting for units to begin executing upgrade of remaining services")
     mojo_utils.upgrade_non_base_services(switch=switch_map)

--- a/helper/setup/upgrade_all_services.py
+++ b/helper/setup/upgrade_all_services.py
@@ -3,6 +3,7 @@ import sys
 import utils.mojo_utils as mojo_utils
 import os
 
+import zaza.model
 from zaza.openstack.utilities import cli as cli_utils
 
 
@@ -12,7 +13,10 @@ def main(argv):
         'neutron-gateway': 'local:{}/{}'.format(os.environ['MOJO_SERIES'],
                                                 'neutron-gateway')
     }
-    mojo_utils.upgrade_all_services(switch=switch_map)
+    mojo_utils.upgrade_base_services(switch=switch_map)
+    zaza.model.block_until_all_units_idle()
+    mojo_utils.upgrade_non_base_services(switch=switch_map)
+    zaza.model.block_until_all_units_idle()
 
 
 if __name__ == "__main__":

--- a/helper/utils/mojo_utils.py
+++ b/helper/utils/mojo_utils.py
@@ -398,22 +398,37 @@ def upgrade_service(svc, charm_name=None, switch=None):
     subprocess.check_call(cmd)
 
 
-def upgrade_all_services(juju_status=None, switch=None):
+BASE_CHARMS = ['mysql', 'percona-cluster', 'rabbitmq-server',
+               'keystone']
+
+
+def upgrade_base_services(juju_status=None, switch=None):
     if not juju_status:
         juju_status = get_juju_status()
     # Upgrade base charms first
-    base_charms = ['mysql', 'percona-cluster', 'rabbitmq-server',
-                   'keystone']
-    for svc in base_charms:
+    for svc in BASE_CHARMS:
         if svc in juju_status['applications']:
             charm_name = charm_to_charm_name(
                 juju_status['applications'][svc]['charm'])
             upgrade_service(svc, charm_name=charm_name, switch=switch)
-            time.sleep(30)
-    time.sleep(60)
+
+
+def upgrade_all_services(juju_status=None, switch=None):
+    upgrade_base_services(
+        juju_status=juju_status,
+        switch=switch)
+    time.sleep(120)
+    upgrade_non_base_services(
+        juju_status=juju_status,
+        switch=switch)
+
+
+def upgrade_non_base_services(juju_status=None, switch=None):
+    if not juju_status:
+        juju_status = get_juju_status()
     # Upgrade the rest
     for svc in juju_status['applications']:
-        if svc not in base_charms:
+        if svc not in BASE_CHARMS:
             charm_name = charm_to_charm_name(
                 juju_status['applications'][svc]['charm'])
             upgrade_service(svc, charm_name=charm_name, switch=switch)


### PR DESCRIPTION
Break up the upgrade_all_services mojo method so it can be called
separately with a zaza block until units are idle rather than blocking
on a sleep. This is a stop gap as this test will be moving to zaza in the very near future.