### PR TITLE
Restart nova after vault setup

### DIFF
--- a/specs/full_stack/next_series_upgrade/queens/manifest
+++ b/specs/full_stack/next_series_upgrade/queens/manifest
@@ -13,6 +13,9 @@ deploy timeout=${MOJO_DEPLOY_TIMEOUT:-5400} config=designate-next-ha.yaml delay=
 # Setup vault
 script config=vault_setup.py
 
+# Restart nova-compute (Bug #1826382)
+script config=restart_nova_compute.py
+
 # Setup ceilometer
 script config=ceilometer_setup.py
 

--- a/specs/full_stack/next_series_upgrade/queens/restart_nova_compute.py
+++ b/specs/full_stack/next_series_upgrade/queens/restart_nova_compute.py
@@ -1,0 +1,1 @@
+../../../../helper/setup/restart_nova_compute.py


### PR DESCRIPTION
As with other specs that use vault, restart nova after vault relation
has been established to work around bug #1826382