### PR TITLE
Drop use of admin-token and admin-password for Keystone charm

### DIFF
--- a/helper/bundles/baremetal7-next.yaml
+++ b/helper/bundles/baremetal7-next.yaml
@@ -77,9 +77,6 @@ openstack-services:
         ephemeral-unmount: "/mnt"
     keystone:
       charm: keystone
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
       to:
         - "lxc:swift-storage-z1=0"
     openstack-dashboard:

--- a/helper/bundles/baremetal7.yaml
+++ b/helper/bundles/baremetal7.yaml
@@ -74,9 +74,6 @@ openstack-services:
         overwrite: "true"
     keystone:
       charm: keystone
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
       to:
         - "lxc:swift-storage-z1=0"
     openstack-dashboard:

--- a/helper/bundles/cephradosgw-ha.yaml
+++ b/helper/bundles/cephradosgw-ha.yaml
@@ -19,9 +19,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     ceph-radosgw:
       charm: ceph-radosgw
       num_units: 4

--- a/helper/bundles/cephradosgw.yaml
+++ b/helper/bundles/cephradosgw.yaml
@@ -20,9 +20,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     glance:
       charm: glance
       constraints: mem=1G

--- a/helper/bundles/deprecated/next-ha.yaml
+++ b/helper/bundles/deprecated/next-ha.yaml
@@ -40,8 +40,6 @@ openstack-services:
       charm: keystone
       constraints: mem=1G
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: 10.5.102.1
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/deprecated/ssl-everywhere.yaml
+++ b/helper/bundles/deprecated/ssl-everywhere.yaml
@@ -30,8 +30,6 @@ openstack-services:
       branch: lp:~openstack-charmers/charms/precise/keystone/ssl-everywhere
       constraints: mem=1G
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         https-service-endpoints: "True"
         use-https: True
     openstack-dashboard:

--- a/helper/bundles/deprecated/swift-ha-proxy-oneshot.yaml
+++ b/helper/bundles/deprecated/swift-ha-proxy-oneshot.yaml
@@ -10,9 +10,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     glance:
       charm: glance
       constraints: mem=1G

--- a/helper/bundles/designate-next-ha-nossl.yaml
+++ b/helper/bundles/designate-next-ha-nossl.yaml
@@ -30,9 +30,6 @@ base-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -44,8 +44,6 @@ base-services:
       constraints: mem=1G
       num_units: 3
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP02 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/dynamic-routing-next.yaml
+++ b/helper/bundles/dynamic-routing-next.yaml
@@ -25,9 +25,6 @@ base-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/full-cells-next.yaml
+++ b/helper/bundles/full-cells-next.yaml
@@ -23,9 +23,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/full-dvr-next.yaml
+++ b/helper/bundles/full-dvr-next.yaml
@@ -22,9 +22,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/full-next-vault.yaml
+++ b/helper/bundles/full-next-vault.yaml
@@ -23,9 +23,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/full-next.yaml
+++ b/helper/bundles/full-next.yaml
@@ -23,9 +23,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/full-osd-reformat-is-text.yaml
+++ b/helper/bundles/full-osd-reformat-is-text.yaml
@@ -28,9 +28,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/full-ssl-next.yaml
+++ b/helper/bundles/full-ssl-next.yaml
@@ -26,8 +26,6 @@ openstack-services:
       charm: keystone
       constraints: mem=1G
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         ssl_ca: include-base64://{{local_dir}}/cacert.pem
         ssl_cert: include-base64://{{local_dir}}/cert.pem
         ssl_key: include-base64://{{local_dir}}/cert.key

--- a/helper/bundles/full-ssl.yaml
+++ b/helper/bundles/full-ssl.yaml
@@ -26,8 +26,6 @@ openstack-services:
       charm: keystone
       constraints: mem=1G
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         ssl_ca: include-base64://{{local_dir}}/cacert.pem
         ssl_cert: include-base64://{{local_dir}}/cert.pem
         ssl_key: include-base64://{{local_dir}}/cert.key

--- a/helper/bundles/full-vrrpha-next.yaml
+++ b/helper/bundles/full-vrrpha-next.yaml
@@ -12,9 +12,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -26,9 +26,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/helper/bundles/ha-next.yaml
+++ b/helper/bundles/ha-next.yaml
@@ -36,8 +36,6 @@ openstack-services:
       constraints: mem=1G
       num_units: 3
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP02 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/ha.yaml
+++ b/helper/bundles/ha.yaml
@@ -38,8 +38,6 @@ openstack-services:
       constraints: mem=1G
       num_units: 3
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP02 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/haphase1-next.yaml
+++ b/helper/bundles/haphase1-next.yaml
@@ -24,8 +24,6 @@ openstack-services:
       constraints: mem=1G
       num_units: 2
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP01 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/haphase1.yaml
+++ b/helper/bundles/haphase1.yaml
@@ -27,8 +27,6 @@ openstack-services:
       constraints: mem=1G
       num_units: 2
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP01 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/haphase2-next.yaml
+++ b/helper/bundles/haphase2-next.yaml
@@ -24,8 +24,6 @@ openstack-services:
       constraints: mem=1G
       num_units: 2
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP01 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/haphase2.yaml
+++ b/helper/bundles/haphase2.yaml
@@ -27,8 +27,6 @@ openstack-services:
       constraints: mem=1G
       num_units: 2
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP01 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/ksv3-full-next.yaml
+++ b/helper/bundles/ksv3-full-next.yaml
@@ -27,8 +27,6 @@ openstack-services:
       charm: keystone
       constraints: mem=1G
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         preferred-api-version: 3
     openstack-dashboard:
       charm: openstack-dashboard

--- a/helper/bundles/ksv3-full.yaml
+++ b/helper/bundles/ksv3-full.yaml
@@ -27,8 +27,6 @@ openstack-services:
       charm: keystone
       constraints: mem=1G
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         preferred-api-version: 3
     openstack-dashboard:
       charm: openstack-dashboard

--- a/helper/bundles/minimal-next.yaml
+++ b/helper/bundles/minimal-next.yaml
@@ -13,9 +13,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     nova-compute:
       charm: nova-compute
       num_units: 1

--- a/helper/bundles/next-ha-nossl.yaml
+++ b/helper/bundles/next-ha-nossl.yaml
@@ -37,8 +37,6 @@ base-services:
       constraints: mem=1G
       num_units: 3
       options:
-        admin-password: openstack
-        admin-token: ubuntutesting
         vip: "{{ MOJO_OS_VIP02 }}"
     keystone-hacluster:
       charm: hacluster

--- a/helper/bundles/ovs-odl.yaml
+++ b/helper/bundles/ovs-odl.yaml
@@ -40,9 +40,6 @@ openstack-services:
       branch: https://github.com/openstack/charm-rabbitmq-server;stable/16.04
     keystone:
       branch: https://github.com/openstack/charm-keystone
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       branch: https://github.com/openstack/charm-openstack-dashboard
     nova-cloud-controller:

--- a/helper/bundles/swift-ha-proxy-phase1.yaml
+++ b/helper/bundles/swift-ha-proxy-phase1.yaml
@@ -10,9 +10,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     glance:
       charm: glance
       constraints: mem=1G

--- a/helper/bundles/swift-proxy.yaml
+++ b/helper/bundles/swift-proxy.yaml
@@ -10,9 +10,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     glance:
       charm: glance
       constraints: mem=1G

--- a/specs/dev/bug1389670/mysql/next-mysql.yaml
+++ b/specs/dev/bug1389670/mysql/next-mysql.yaml
@@ -18,9 +18,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
 # see NOTE [0]
 #    ceph:
 #      charm: ceph

--- a/specs/dev/bug1389670/percona_cluster/next-percona.yaml
+++ b/specs/dev/bug1389670/percona_cluster/next-percona.yaml
@@ -20,9 +20,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     nova-compute:
       num_units: 2
       charm: nova-compute

--- a/specs/dev/dvr/full_dvr.yaml
+++ b/specs/dev/dvr/full_dvr.yaml
@@ -23,9 +23,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/specs/dev/full_nrpe/next.yaml
+++ b/specs/dev/full_nrpe/next.yaml
@@ -23,9 +23,6 @@ openstack-services:
     keystone:
       branch: lp:~openstack-charmers/charms/trusty/keystone/next
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       branch: lp:~openstack-charmers/charms/trusty/openstack-dashboard/next
       constraints: mem=1G

--- a/specs/dev/keystone_ssl/next-ssl.yaml
+++ b/specs/dev/keystone_ssl/next-ssl.yaml
@@ -53,8 +53,6 @@ openstack-services:
       options:
         debug: 'true'
         verbose: 'true'
-        admin-password: openstack
-        admin-token: ubuntutesting
         enable-pki: 'true'
         https-service-endpoints: 'True'
         use-https: 'yes'

--- a/specs/dev/neutron_ha/neutronha.yaml
+++ b/specs/dev/neutron_ha/neutronha.yaml
@@ -23,9 +23,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G

--- a/specs/dev/next_mini/mini.yaml
+++ b/specs/dev/next_mini/mini.yaml
@@ -13,9 +13,6 @@ openstack-base:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     nova-compute:
       charm: nova-compute
       num_units: 1

--- a/specs/dev/nova_cc_legacy_neutron/next-n-api.yaml
+++ b/specs/dev/nova_cc_legacy_neutron/next-n-api.yaml
@@ -12,9 +12,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     nova-cloud-controller-hacluster:
       charm: hacluster
     nova-cloud-controller:

--- a/specs/dev/nova_cc_legacy_neutron/next-no-n-api.yaml
+++ b/specs/dev/nova_cc_legacy_neutron/next-no-n-api.yaml
@@ -12,9 +12,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     nova-cloud-controller-hacluster:
       charm: hacluster
     nova-cloud-controller:

--- a/specs/dev/stable_mini/mini.yaml
+++ b/specs/dev/stable_mini/mini.yaml
@@ -13,9 +13,6 @@ openstack-base:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     nova-compute:
       charm: nova-compute
       num_units: 1

--- a/specs/dev/swift_nrpe/simple_nonha/swift-proxy.yaml
+++ b/specs/dev/swift_nrpe/simple_nonha/swift-proxy.yaml
@@ -10,9 +10,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     glance:
       charm: glance
       constraints: mem=1G

--- a/specs/dev/vxlan/full_dvr.yaml
+++ b/specs/dev/vxlan/full_dvr.yaml
@@ -23,9 +23,6 @@ openstack-services:
     keystone:
       charm: keystone
       constraints: mem=1G
-      options:
-        admin-password: openstack
-        admin-token: ubuntutesting
     openstack-dashboard:
       charm: openstack-dashboard
       constraints: mem=1G


### PR DESCRIPTION
``admin-token`` has been removed from the charm.

The Zaza helpers are capable of retrieving the generated admin
credentails from Keystone and thus hard coding a password in the
test is no longer required.