### PR TITLE
Double timeout when waiting for units to finish charm upgrade

### DIFF
--- a/helper/setup/upgrade_all_services.py
+++ b/helper/setup/upgrade_all_services.py
@@ -23,14 +23,14 @@ def main(argv):
         "Waiting for units to begin executing upgrade of base services")
     zaza.model.wait_for_agent_status(status='executing')
     logging.info("Waiting for units to be idle")
-    zaza.model.block_until_all_units_idle()
+    zaza.model.block_until_all_units_idle(timeout=5400)
 
     logging.info("Upgrading remaining services")
     logging.info(
         "Waiting for units to begin executing upgrade of remaining services")
     mojo_utils.upgrade_non_base_services(switch=switch_map)
     logging.info("Waiting for units to be idle")
-    zaza.model.block_until_all_units_idle()
+    zaza.model.block_until_all_units_idle(timeout=5400)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
OSCI has seen repeated failures where the test has timed out waiting for units to be idle *1. This is basically a wait for applications to have their charms upgraded. A successful run was completed with this branch *2 



*1 https://bugs.launchpad.net/charm-test-infra/+bug/1870298
*2 http://10.245.162.58:8080/view/MojoMatrix/job/mojo_runner/22019/console