### PR TITLE
Add traces to series_upgrade.py

### DIFF
--- a/helper/tests/series_upgrade.py
+++ b/helper/tests/series_upgrade.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import sys
 
@@ -35,8 +36,11 @@ if __name__ == "__main__":
     elif from_series == "xenial":
         to_series = "bionic"
         series_upgrade_test = XenialBionicSeriesUpgrade()
-
     else:
         raise Exception("MOJO_SERIES is not set to a vailid LTS series")
+    logging.info("Preparing series upgrade test from {} to {}".format(
+        from_series, to_series))
+    logging.info("Setting up...")
     series_upgrade_test.setUpClass()
+    logging.info("Running series upgrade test...")
     sys.exit(series_upgrade_test.test_200_run_series_upgrade())


### PR DESCRIPTION
Adding traces to understand why [this run](http://osci:8080/job/mojo_runner/22578/console) was stuck for days right after launching `series_upgrade.py`.

Validating [here](http://osci:8080/job/mojo_runner/22606)