### PR TITLE
Add in required cinder-ceph ceph-access relation to nova-compute

### DIFF
--- a/helper/bundles/baremetal7-next.yaml
+++ b/helper/bundles/baremetal7-next.yaml
@@ -311,6 +311,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -336,6 +338,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/baremetal7.yaml
+++ b/helper/bundles/baremetal7.yaml
@@ -307,6 +307,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -320,6 +322,8 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: openstack-icehouse
   series: xenial
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -332,6 +336,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/full-cells-next.yaml
+++ b/helper/bundles/full-cells-next.yaml
@@ -167,6 +167,7 @@ openstack-services:
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
+    - [ cinder-ceph, nova-compute ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/full-dvr-next.yaml
+++ b/helper/bundles/full-dvr-next.yaml
@@ -232,6 +232,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -245,6 +247,8 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: openstack-icehouse
   series: xenial
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -255,6 +259,8 @@ xenial-newton:
   series: xenial
   overrides:
     openstack-origin: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
     source: cloud:xenial-newton
 # ocata
 xenial-ocata:

--- a/helper/bundles/full-dvr-next.yaml
+++ b/helper/bundles/full-dvr-next.yaml
@@ -259,9 +259,9 @@ xenial-newton:
   series: xenial
   overrides:
     openstack-origin: cloud:xenial-newton
+    source: cloud:xenial-newton
   relations:
     - [ cinder-ceph, nova-compute ]
-    source: cloud:xenial-newton
 # ocata
 xenial-ocata:
   inherits: openstack-icehouse

--- a/helper/bundles/full-next.yaml
+++ b/helper/bundles/full-next.yaml
@@ -294,11 +294,15 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
     openstack-origin: cloud:trusty-mitaka/proposed
     source: cloud:trusty-proposed/mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-staging:
   inherits: trusty-mitaka
   overrides:
@@ -307,6 +311,8 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: xenial
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -319,6 +325,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/full-ssl-next.yaml
+++ b/helper/bundles/full-ssl-next.yaml
@@ -335,6 +335,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -348,6 +350,8 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: xenial
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -360,6 +364,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/full-ssl.yaml
+++ b/helper/bundles/full-ssl.yaml
@@ -329,6 +329,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -342,6 +344,8 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: xenial
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -354,6 +358,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -131,14 +131,14 @@ ceilometer-mongodb:
       constraints: mem=1G
   relations:
     - - ceilometer
-      - keystone:identity-service
+      - "keystone:identity-service"
     - - ceilometer
-      - keystone:identity-notifications
+      - "keystone:identity-notifications"
     - [ "ceilometer:amqp", rabbitmq-server ]
     - [ ceilometer, mongodb ]
     - [ ceilometer-agent, nova-compute ]
     - [ ceilometer-agent, ceilometer ]
-    - [ ceilometer-agent:amqp, rabbitmq-server:amqp]
+    - [ "ceilometer-agent:amqp", "rabbitmq-server:amqp"]
 charm-ceilometer-gnocchi:
   services:
     ceilometer:
@@ -150,12 +150,12 @@ charm-ceilometer-gnocchi:
       charm: gnocchi
   relations:
     - - ceilometer
-      - keystone:identity-notifications
+      - "keystone:identity-notifications"
     - [ "ceilometer:amqp", rabbitmq-server ]
     - [ ceilometer, gnocchi ]
     - [ ceilometer-agent, nova-compute ]
     - [ ceilometer-agent, ceilometer ]
-    - [ ceilometer-agent:amqp, rabbitmq-server:amqp]
+    - [ "ceilometer-agent:amqp", "rabbitmq-server:amqp"]
     - - ceph-mon
       - gnocchi
     - - gnocchi
@@ -170,7 +170,7 @@ ceilometer-gnocchi:
   inherits: [ charm-ceilometer-gnocchi]
   relations:
     - - ceilometer
-      - keystone:identity-credentials
+      - "keystone:identity-credentials"
 openstack-singlerabbit:
   inherits: openstack-services
   relations:

--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -299,6 +299,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -318,6 +320,7 @@ xenial-mitaka:
       constraints: mem=1G
   relations:
     - [ keystone, tempest ]
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -330,6 +333,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/ha-next.yaml
+++ b/helper/bundles/ha-next.yaml
@@ -301,17 +301,23 @@ trusty-mitaka-ha:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: trusty
   overrides:
     openstack-origin: cloud:trusty-mitaka/proposed
     source: cloud:trusty-mitaka/proposed
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: xenial
   overrides:
     ha-bindiface: ens2
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -325,6 +331,8 @@ xenial-newton-ha:
     ha-bindiface: ens2
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # ocata
 xenial-ocata-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]

--- a/helper/bundles/ha.yaml
+++ b/helper/bundles/ha.yaml
@@ -231,15 +231,15 @@ ceilometer-mongodb:
       constraints: mem=1G
   relations:
     - - ceilometer
-      - keystone:identity-service
+      - "keystone:identity-service"
     - - ceilometer
-      - keystone:identity-notifications
+      - "keystone:identity-notifications"
     - [ "ceilometer:amqp", rabbitmq-server ]
     - [ ceilometer, mongodb ]
     - [ ceilometer-agent, nova-compute ]
     - [ ceilometer-agent, ceilometer ]
     - [ ceilometer, ceilometer-hacluster ]
-    - [ ceilometer-agent:amqp, rabbitmq-server:amqp]
+    - [ "ceilometer-agent:amqp", "rabbitmq-server:amqp"]
 charm-ceilometer-gnocchi:
   services:
     ceilometer:
@@ -259,12 +259,12 @@ charm-ceilometer-gnocchi:
       charm: gnocchi
   relations:
     - - ceilometer
-      - keystone:identity-notifications
+      - "keystone:identity-notifications"
     - [ "ceilometer:amqp", rabbitmq-server ]
     - [ ceilometer, gnocchi ]
     - [ ceilometer-agent, nova-compute ]
     - [ ceilometer-agent, ceilometer ]
-    - [ ceilometer-agent:amqp, rabbitmq-server:amqp]
+    - [ "ceilometer-agent:amqp", "rabbitmq-server:amqp"]
     - - ceph-mon
       - gnocchi
     - - gnocchi

--- a/helper/bundles/ha.yaml
+++ b/helper/bundles/ha.yaml
@@ -304,23 +304,31 @@ trusty-mitaka-ha:
   overrides:
     openstack-origin: cloud:trusty-mitaka/proposed
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: trusty
   overrides:
     openstack-origin: cloud:trusty-mitaka/proposed
     source: cloud:trusty-mitaka/proposed
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: xenial
   overrides:
     ha-bindiface: ens2
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
     source: proposed
     openstack-origin: distro-proposed
     ha-bindiface: ens2
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]
   series: xenial
@@ -328,6 +336,8 @@ xenial-newton-ha:
     ha-bindiface: ens2
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 # ocata
 xenial-ocata-ha:
   inherits: [ openstack-services, ceilometer-mongodb ]

--- a/helper/bundles/ksv3-full-next.yaml
+++ b/helper/bundles/ksv3-full-next.yaml
@@ -307,6 +307,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -320,6 +322,8 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: [ openstack-icehouse, ceilometer-mongodb ]
   series: xenial
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -332,6 +336,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/ksv3-full.yaml
+++ b/helper/bundles/ksv3-full.yaml
@@ -305,6 +305,8 @@ trusty-mitaka:
   overrides:
     openstack-origin: cloud:trusty-mitaka
     source: cloud:trusty-mitaka
+  relations:
+    - [ cinder-ceph, nova-compute ]
 trusty-mitaka-proposed:
   inherits: trusty-mitaka
   overrides:
@@ -318,6 +320,8 @@ trusty-mitaka-staging:
 xenial-mitaka:
   inherits: [ openstack-icehouse-msg-split, ceilometer-mongodb ]
   series: xenial
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-mitaka-proposed:
   inherits: xenial-mitaka
   overrides:
@@ -330,6 +334,8 @@ xenial-newton:
   overrides:
     openstack-origin: cloud:xenial-newton
     source: cloud:xenial-newton
+  relations:
+    - [ cinder-ceph, nova-compute ]
 xenial-newton-proposed:
   inherits: xenial-newton
   overrides:

--- a/helper/bundles/next-ha-nossl.yaml
+++ b/helper/bundles/next-ha-nossl.yaml
@@ -197,6 +197,7 @@ base-services:
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
     - [ cinder-ceph, ceph-mon ]
+    - [ cinder-ceph, nova-compute ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/scripts/mojo_spec_check.py
+++ b/helper/scripts/mojo_spec_check.py
@@ -234,9 +234,9 @@ def check_yaml_syntax(dir_list):
             stream = open(f, 'r')
             try:
                 yaml.safe_load(stream)
-            except yaml.scanner.ScannerError:
-                logging.error('%s contains yaml errors, '
-                              'mojo spec will fail.' % f)
+            except yaml.scanner.ScannerError as e:
+                logging.error('{} contains yaml errors, mojo spec will fail,'
+                              ' due to "{}"'.format(f, str(e)))
 
 
 def check_for_ambiguous_relations(dir_list):


### PR DESCRIPTION
Due to the linked bug [1], (some) mojo runs will fail as the cinder-ceph
charm now requires the ceph-access relation, and this needs to be
related to nova-compute.  This adds it to the bundles/combinations that
are current at the time of this commit.

[1]: https://bugs.launchpad.net/openstack-mojo-specs/+bug/1881246