### PR TITLE
Pin mongodb charm to version 53

### DIFF
--- a/helper/collect/collect-next-ha-trusty
+++ b/helper/collect/collect-next-ha-trusty
@@ -8,7 +8,7 @@ glance                 cs:~openstack-charmers-next/glance
 hacluster              cs:~openstack-charmers-next/hacluster
 heat                   cs:~openstack-charmers-next/heat
 keystone               cs:~openstack-charmers-next/keystone
-mongodb                cs:trusty/mongodb
+mongodb                cs:trusty/mongodb-53
 neutron-api            cs:~openstack-charmers-next/neutron-api
 neutron-gateway        cs:~openstack-charmers-next/neutron-gateway
 neutron-openvswitch    cs:~openstack-charmers-next/neutron-openvswitch


### PR DESCRIPTION
Due to this bug [1], mongodb won't currently install on trusty.  As we
only use trusty as a way of upgrading to xenial, pin mongodb back to a
known good version on trusty.

[1]: https://bugs.launchpad.net/charm-mongodb/+bug/1882641