### PR TITLE
Fix ambiguous relation

### DIFF
--- a/helper/bundles/baremetal7-next.yaml
+++ b/helper/bundles/baremetal7-next.yaml
@@ -155,7 +155,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/baremetal7.yaml
+++ b/helper/bundles/baremetal7.yaml
@@ -152,7 +152,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/designate-next-ha-nossl.yaml
+++ b/helper/bundles/designate-next-ha-nossl.yaml
@@ -130,7 +130,7 @@ base-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/designate-next-ha.yaml
+++ b/helper/bundles/designate-next-ha.yaml
@@ -226,7 +226,7 @@ base-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/dynamic-routing-next.yaml
+++ b/helper/bundles/dynamic-routing-next.yaml
@@ -121,7 +121,7 @@ base-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/full-cells-next.yaml
+++ b/helper/bundles/full-cells-next.yaml
@@ -166,7 +166,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ cinder-ceph, nova-compute ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]

--- a/helper/bundles/full-dvr-next.yaml
+++ b/helper/bundles/full-dvr-next.yaml
@@ -98,7 +98,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]
     - [ swift-proxy, swift-storage-z1 ]

--- a/helper/bundles/full-next.yaml
+++ b/helper/bundles/full-next.yaml
@@ -105,7 +105,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/full-ssl-next.yaml
+++ b/helper/bundles/full-ssl-next.yaml
@@ -128,7 +128,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/full-ssl.yaml
+++ b/helper/bundles/full-ssl.yaml
@@ -128,7 +128,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/full.yaml
+++ b/helper/bundles/full.yaml
@@ -112,7 +112,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/ha-next.yaml
+++ b/helper/bundles/ha-next.yaml
@@ -181,7 +181,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/ha.yaml
+++ b/helper/bundles/ha.yaml
@@ -184,7 +184,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/ksv3-full-next.yaml
+++ b/helper/bundles/ksv3-full-next.yaml
@@ -112,7 +112,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/ksv3-full.yaml
+++ b/helper/bundles/ksv3-full.yaml
@@ -112,7 +112,7 @@ openstack-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]
     - [ swift-proxy, keystone ]

--- a/helper/bundles/next-ha-nossl.yaml
+++ b/helper/bundles/next-ha-nossl.yaml
@@ -196,7 +196,7 @@ base-services:
     - [ cinder, nova-cloud-controller ]
     - [ cinder, keystone ]
     - [ cinder, cinder-ceph ]
-    - [ cinder-ceph, ceph-mon ]
+    - [ "cinder-ceph:ceph", "ceph-mon:client" ]
     - [ cinder-ceph, nova-compute ]
     - [ neutron-gateway, nova-cloud-controller ]
     - [ "openstack-dashboard:identity-service", keystone ]


### PR DESCRIPTION
cinder-ceph grew a new relation in [1].  Fix the ambiguous relation in
the bundles.

cinder-ceph/ceph-mon could now refer to:
- ceph/client
- ceph-replication-device/client
- juju-info/juju-info

[1]: https://review.opendev.org/c/openstack/charm-cinder-ceph/+/764004