### PR TITLE
Enable a large Juju MAX_FRAME_SIZE for vault_setup.py

### DIFF
--- a/helper/setup/vault_setup.py
+++ b/helper/setup/vault_setup.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     del wl_statuses['vault']
     model.block_until_file_has_contents(
         'keystone',
-        '/usr/local/share/ca-certificates/vault_juju_ca_cert.crt',
+        '/usr/local/share/ca-certificates/keystone_juju_ca_cert.crt',
         cacert.decode().strip())
     model.wait_for_application_states(
         states=wl_statuses)

--- a/helper/setup/vault_setup.py
+++ b/helper/setup/vault_setup.py
@@ -3,6 +3,7 @@
 # import asyncio  # Unused import
 import copy
 import os
+import juju
 from zaza import model
 from zaza.openstack.utilities import (
     cli as cli_utils,
@@ -18,6 +19,10 @@ import logging
 
 
 if __name__ == "__main__":
+    # NOTE(ajkavanagh): Set the jujulib Connection frame size to 4GB to
+    # cope with all the outputs from large models that have had lots of status
+    # changes.
+    juju.client.connection.Connection.MAX_FRAME_SIZE = 2**32
     cli_utils.setup_logging()
     target_model = model.get_juju_model()
     wl_statuses = copy.deepcopy(openstack.WORKLOAD_STATUS_EXCEPTIONS)
@@ -64,7 +69,7 @@ if __name__ == "__main__":
     del wl_statuses['vault']
     model.block_until_file_has_contents(
         'keystone',
-        '/usr/local/share/ca-certificates/keystone_juju_ca_cert.crt',
+        '/usr/local/share/ca-certificates/vault_juju_ca_cert.crt',
         cacert.decode().strip())
     model.wait_for_application_states(
         states=wl_statuses)


### PR DESCRIPTION
python_libjuju has connection problems with large models where there
have been a lot of status changes as the state exceeds the frame size
for the connection.  This results in strange disconnection errors whilst
waiting for the model to settle.