### PR TITLE
Fix spelling mistake in vault_setup.py (get_credentials)

### DIFF
--- a/helper/setup/vault_setup.py
+++ b/helper/setup/vault_setup.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     logging.info("Vault setup basic ...")
     vault_setup.basic_setup(cacert=certfile)
     clients = vault_utils.get_clients(cacert=certfile)
-    vault_creds = vault_utils.get_credentails()
+    vault_creds = vault_utils.get_credentials()
     vault_utils.unseal_all(clients, vault_creds['keys'][0])
     action = vault_utils.run_charm_authorize(
         vault_creds['root_token'])


### PR DESCRIPTION
zaza.openstack.tests originally had a method called `get_credentails()`
that is used from vault_setup.py.  This was fixed in
zaza.openstack.tests commit 66d08c08 but that subsequently broke
vault_setup.py.  This patch fixes it here too.